### PR TITLE
Update README for JOSS Installation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,22 @@ Internally, APE uses a component-based program synthesis approach. It translates
 
 ## Requirements
 
-In order to run APE you need to have Java 1.8 (or higher) installed on the system.
+In order to [run](https://github.com/sanctuuary/APE#command-line-interface-cli) APE you need to have [Java 1.8](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html) (or higher) installed on the system. To [build](https://github.com/sanctuuary/APE#how-to-build-ape-from-source) the APE module from source code, [Maven 3.3+](https://maven.apache.org/download.cgi) has to be installed as well.
+
+## Downloads
+
+| Date       | Version | Download                                                                             |
+|------------|---------|--------------------------------------------------------------------------------------|
+| 01-06-2020 | 1.0.0   | [APE-1.0.0.jar](https://github.com/sanctuuary/APE_UseCases/raw/master/APE-1.0.0.jar) |
+
+## How to build APE from source
+
+### Using Maven
+Simply launch
+```shell
+$ mvn -DskipTests=true install
+```
+to build the APE modules from the source tree and the built files will be generated under /target directory. All the dependencies will be gathered by Maven.
 
 ## CLI & API
 Automated workflow composition with APE can be performed through its command line interface (CLI) or its application programming interface (API). While the CLI provides a simple means to interact and experiment with the system, the API provides more flexibility and control over the synthesis process. It can be used to integrate APE’s functionality into other systems.
@@ -33,20 +48,13 @@ For more details check a [simple demo](https://github.com/sanctuuary/APE_UseCase
 
 Like the CLI, the APE API relies on a configuration file that references the domain ontology, tool annotations, workflow specification and execution parameters. However, the API allows to edit this file programmatically, and thus for instance add constraints or change execution parameters dynamically.
 
+
+
 ## Demo 
 A web browser demonstrator (beta) of can be found at: http://ape.science.uu.nl/
 Docker version of the demonstrator is available at: https://github.com/sanctuuary/Burke_Docker
 
 Our use cases are motivated by practical problems in various domains (e.g. bioinformatisc, GIS). Multiple predefined scenarios of scientific workflow synthesis can be found at [GitHub Use Cases Repository](https://github.com/sanctuuary/APE_UseCases).
-
-## How to build APE from source
-
-### Using Maven
-Simply launch
-```shell
-$ mvn -DskipTests=true install
-```
-to build the APE modules from the source tree and the built files will be generated under /target directory. All the dependencies will be gathered by Maven.
 
 ## Credits
 APE has been inspired by the [Loose Programming framework PROPHETS](http://ls5-www.cs.tu-dortmund.de/projects/prophets/index.php). It uses similar mechanisms for semantic domain modeling, workflow specification and synthesis, but strives to provide the automated composition functionality independent from a concrete workflow system.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Internally, APE uses a component-based program synthesis approach. It translates
 In order to [run](https://github.com/sanctuuary/APE#command-line-interface-cli) APE you need to have [Java 1.8](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html) (or higher) installed on the system. To [build](https://github.com/sanctuuary/APE#how-to-build-ape-from-source) the APE module from source code, [Maven 3.3+](https://maven.apache.org/download.cgi) has to be installed as well.
 
 ## Downloads
-
 | Date       | Version | Download                                                                             |
 |------------|---------|--------------------------------------------------------------------------------------|
 | 01-06-2020 | 1.0.0   | [APE-1.0.0.jar](https://github.com/sanctuuary/APE_UseCases/raw/master/APE-1.0.0.jar) |
@@ -21,11 +20,11 @@ In order to [run](https://github.com/sanctuuary/APE#command-line-interface-cli) 
 ## How to build APE from source
 
 ### Using Maven
-Simply launch
+From the project root, simply launch
 ```shell
 $ mvn -DskipTests=true install
 ```
-to build the APE modules from the source tree and the built files will be generated under /target directory. All the dependencies will be gathered by Maven.
+to build the APE modules from the source tree and the built files will be generated under the `/target` directory. All the dependencies will be gathered by Maven and the following stand-alone module will be generated: `APE-<version>-jar-with-dependencies.jar`
 
 ## CLI & API
 Automated workflow composition with APE can be performed through its command line interface (CLI) or its application programming interface (API). While the CLI provides a simple means to interact and experiment with the system, the API provides more flexibility and control over the synthesis process. It can be used to integrate APE’s functionality into other systems.
@@ -39,16 +38,38 @@ When running APE-&lt;version>.jar from the command line, it requires a JSON conf
 To run the APE CLI use:
 
 ```shell
- java -jar APE-<version>.jar SimpleDemo/ape.configuration
+> java -jar APE-<version>.jar configuration.json
 ```
 
 For more details check a [simple demo](https://github.com/sanctuuary/APE_UseCases/tree/master/SimpleDemo).
 
 ### Application Programming Interface (API)
 
-Like the CLI, the APE API relies on a configuration file that references the domain ontology, tool annotations, workflow specification and execution parameters. However, the API allows to edit this file programmatically, and thus for instance add constraints or change execution parameters dynamically.
+Like the CLI, the APE API relies on a configuration file that references the domain ontology, tool annotations, workflow specification and execution parameters.
 
+```java
+// set up the framework
+APE ape = new APE("path/to/setup-configuration.json");
 
+// run the synthesis
+SATsolutionsList solutions = ape.runSynthesis("path/to/run-configuration.json");
+```
+
+However, the API allows to edit this file programmatically, and thus for instance add constraints or change execution parameters dynamically. 
+
+```java
+// set up the framework
+JSONObject setupConfig = ...
+APE ape = new APE(setupConfig);
+
+// run the synthesis
+JSONObject runConfig = ...
+SATsolutionsList solutions1 = ape.runSynthesis(runconfig);
+
+// run the synthesis again with altered parameters
+runConfig.put("use_workflow_input", "ONE");
+SATsolutionsList solutions2 = ape.runSynthesis(runconfig);
+```
 
 ## Demo 
 A web browser demonstrator (beta) of can be found at: http://ape.science.uu.nl/
@@ -62,13 +83,12 @@ APE has been inspired by the [Loose Programming framework PROPHETS](http://ls5-w
 We thank our brave first-generation users for their patience and constructive feedback that helped us to get APE into shape. 
 
 ## License
-APE is licensed under the Apache 2.0 license.
+APE is licensed under the [Apache 2.0](https://github.com/sanctuuary/APE/blob/master/LICENSE) license.
 
 #### Maven dependencies
 
-1. **OWL API**	-	LGPL or Apache 2.0
-2. **SAT4J**	-	EPL or GNu LGPL
-3. **apache-common-lang**	-	Apache 2.0
-4. **graphviz-java** - Apache 2.0
-5. **org.json** - [JSON license](https://www.json.org/license.html)
-
+1. [**OWL API**](https://mvnrepository.com/artifact/net.sourceforge.owlapi/owlapi-distribution) - LGPL or Apache 2.0
+2. [**SAT4J**](https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core) - EPL or GNu LGPL
+3. [**apache-common-lang**](https://mvnrepository.com/artifact/org.apache.commons/commons-lang3) - Apache 2.0
+4. [**graphviz-java**](https://mvnrepository.com/artifact/guru.nidi/graphviz-java) - Apache 2.0
+5. [**org.json**](https://mvnrepository.com/artifact/org.json/json) - [JSON license](https://www.json.org/license.html)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When running APE-&lt;version>.jar from the command line, it requires a JSON conf
 To run the APE CLI use:
 
 ```shell
-> java -jar APE-<version>.jar configuration.json
+java -jar APE-<version>.jar configuration.json
 ```
 
 For more details check a [simple demo](https://github.com/sanctuuary/APE_UseCases/tree/master/SimpleDemo).

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.uu.sanctuuary</groupId>
 	<artifactId>APE</artifactId>
-	<version>1.0.0</version>
+	<version>0.9.4</version>
 	<packaging>jar</packaging>
 	<name>nl.uu.cs:APE</name>
 	<description>APE is a command line tool and an API for the automated exploration of possible computational pipelines (workflows) from large collections of computational tools.</description>
@@ -39,8 +39,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-   					 <target>1.8</target>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
@@ -64,8 +62,6 @@
 				<artifactId>maven-source-plugin</artifactId>
 				<version>3.0.1</version>
 				<configuration>
-					<source>1.8</source>
-   					 <target>1.8</target>
 				</configuration>
 				<executions>
 					<execution>
@@ -81,6 +77,23 @@
           		<artifactId>maven-surefire-plugin</artifactId>
           		<version>3.0.0-M4</version>
         	</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-site-plugin</artifactId>
+				<version>3.7.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.uu.sanctuuary</groupId>
 	<artifactId>APE</artifactId>
-	<version>0.9.4</version>
+	<version>1.0.0</version>
 	<packaging>jar</packaging>
 	<name>nl.uu.cs:APE</name>
 	<description>APE is a command line tool and an API for the automated exploration of possible computational pipelines (workflows) from large collections of computational tools.</description>
@@ -39,6 +39,8 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
+					<source>1.8</source>
+   					 <target>1.8</target>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
@@ -62,6 +64,8 @@
 				<artifactId>maven-source-plugin</artifactId>
 				<version>3.0.1</version>
 				<configuration>
+					<source>1.8</source>
+   					 <target>1.8</target>
 				</configuration>
 				<executions>
 					<execution>
@@ -77,23 +81,6 @@
           		<artifactId>maven-surefire-plugin</artifactId>
           		<version>3.0.0-M4</version>
         	</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-site-plugin</artifactId>
-				<version>3.7.1</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Added to the main README:
- Download link to jar
- API Example
- Dependency hyperlink

Changed the order to be:
1. Requirements
2. Downloads
3. Build from source
4. CLI
5. API
6. Demo
7. Credits
8. License
9. Dependencies