### PR TITLE
APEConfig(Exception) implementation

### DIFF
--- a/src/main/java/nl/uu/cs/ape/sat/APE.java
+++ b/src/main/java/nl/uu/cs/ape/sat/APE.java
@@ -9,10 +9,7 @@ import nl.uu.cs.ape.sat.core.implSAT.SAT_SynthesisEngine;
 import nl.uu.cs.ape.sat.core.implSAT.SATsolutionsList;
 import nl.uu.cs.ape.sat.core.solutionStructure.SolutionWorkflow;
 import nl.uu.cs.ape.sat.models.logic.constructs.TaxonomyPredicate;
-import nl.uu.cs.ape.sat.utils.APEConfig;
-import nl.uu.cs.ape.sat.utils.APEDomainSetup;
-import nl.uu.cs.ape.sat.utils.APEUtils;
-import nl.uu.cs.ape.sat.utils.OWLReader;
+import nl.uu.cs.ape.sat.utils.*;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -38,17 +35,17 @@ public class APE {
      * Create instance of the APE solver.
      *
      * @param configPath Path to the APE configuration file. If the string is null the default './ape.config' value is assumed.
-     * @throws IOException                 Exception while reading the configuration file.
-     * @throws JSONException               Exception while reading the configuration file.
-     * @throws ExceptionInInitializerError the exception in initializer error
+     * @throws IOException        Exception while reading the configuration file.
+     * @throws JSONException      Exception while reading the configuration file.
+     * @throws APEConfigException Error in setting up the the configuration.
      */
-    public APE(String configPath) throws IOException, JSONException, ExceptionInInitializerError {
+    public APE(String configPath) throws IOException, JSONException, APEConfigException {
         config = new APEConfig(configPath);
-        if (config == null || config.getCoreConfigJsonObj() == null) {
-            throw new ExceptionInInitializerError("Configuration failed. Error in configuration file.");
+        if (config.getCoreConfigJsonObj() == null) {
+            throw new APEConfigException("Configuration failed. Error in configuration file.");
         }
         if (!setupDomain()) {
-            throw new IOException("Error in settin up the domain.");
+            throw new APEConfigException("Error in setting up the domain.");
         }
     }
 
@@ -56,17 +53,14 @@ public class APE {
      * Create instance of the APE solver.
      *
      * @param configObject The APE configuration JSONObject{@link JSONObject}.
-     * @throws ExceptionInInitializerError Exception while reading the configuration file.
-     * @throws IOException                 Exception while reading the configuration file.
+     * @throws IOException        Exception while reading the configuration file.
+     * @throws JSONException      Exception while reading the configuration file.
+     * @throws APEConfigException Error in setting up the the configuration.
      */
-    public APE(JSONObject configObject) throws ExceptionInInitializerError, IOException {
+    public APE(JSONObject configObject) throws IOException, JSONException, APEConfigException {
         config = new APEConfig(configObject);
-        if (config == null) {
-            System.err.println("Configuration failed. Error in configuration object.");
-            throw new ExceptionInInitializerError();
-        }
         if (!setupDomain()) {
-            throw new IOException("Error in setting up the domain.");
+            throw new APEConfigException("Error in setting up the domain.");
         }
     }
 
@@ -171,11 +165,10 @@ public class APE {
      * @throws IOException   Error in case of not providing a proper configuration file.
      * @throws JSONException Error in configuration object.
      */
-    public SATsolutionsList runSynthesis(JSONObject configObject, APEDomainSetup apeDomainSetup)
-            throws IOException, JSONException {
+    public SATsolutionsList runSynthesis(JSONObject configObject, APEDomainSetup apeDomainSetup) throws IOException, JSONException, APEConfigException {
         apeDomainSetup.clearConstraints();
         config.setupRunConfiguration(configObject, apeDomainSetup);
-        if (config == null || config.getRunConfigJsonObj() == null) {
+        if (config.getRunConfigJsonObj() == null) {
             throw new JSONException("Run configuration failed. Error in configuration object.");
         }
         SATsolutionsList solutions = executeSynthesis();
@@ -192,12 +185,12 @@ public class APE {
      * @throws IOException   Error in case of not providing a proper configuration file.
      * @throws JSONException Error in configuration object.
      */
-    public SATsolutionsList runSynthesis(String configPath, APEDomainSetup apeDomainSetup)
-            throws IOException, JSONException {
+    public SATsolutionsList runSynthesis(String configPath, APEDomainSetup apeDomainSetup) throws IOException, JSONException, APEConfigException {
         config.setupRunConfiguration(configPath, apeDomainSetup);
-        if (config == null || config.getRunConfigJsonObj() == null) {
+        if (config.getRunConfigJsonObj() == null) {
             throw new JSONException("Run configuration failed. Error in configuration file.");
         }
+
         SATsolutionsList solutions = executeSynthesis();
 
         return solutions;

--- a/src/main/java/nl/uu/cs/ape/sat/LocalRun.java
+++ b/src/main/java/nl/uu/cs/ape/sat/LocalRun.java
@@ -2,6 +2,7 @@ package nl.uu.cs.ape.sat;
 
 import guru.nidi.graphviz.attribute.RankDir;
 import nl.uu.cs.ape.sat.core.implSAT.SATsolutionsList;
+import nl.uu.cs.ape.sat.utils.APEConfigException;
 import nl.uu.cs.ape.sat.utils.APEUtils;
 import org.json.JSONException;
 
@@ -35,34 +36,36 @@ public class LocalRun {
 
         APE apeFramework = null;
         try {
+
+            // set up the APE framework
             apeFramework = new APE(file.getAbsolutePath());
-        } catch (JSONException e) {
+
+        } catch (APEConfigException | JSONException | IOException e) {
+            System.err.println("Error in setting up the APE framework:");
             System.err.println(e.getMessage());
             return;
-        } catch (IOException e) {
-            System.err.println(e.getMessage());
-            return;
-        } catch (ExceptionInInitializerError e) {
-            System.err.println(e.getMessage());
         }
 
         SATsolutionsList solutions;
         try {
+
+            // run the synthesis and retrieve the solutions
             solutions = apeFramework.runSynthesis(file.getAbsolutePath(), apeFramework.getDomainSetup());
-        } catch (IOException e) {
-            System.err.println("Error in synthesis execution. Writing to the file system failed.");
+
+        } catch (APEConfigException | JSONException | IOException e) {
+            System.err.println("Error in synthesis execution:");
+            System.err.println(e.getMessage());
             return;
         }
 
         /*
          * Writing solutions to the specified file in human readable format
          */
-        if (solutions == null) {
-
-        } else if (solutions.isEmpty()) {
+        if (solutions != null && solutions.isEmpty()) {
             System.out.println("UNSAT");
         } else {
             try {
+                assert solutions != null;
                 apeFramework.writeSolutionToFile(solutions);
                 apeFramework.writeDataFlowGraphs(solutions, RankDir.TOP_TO_BOTTOM);
 //				apeFramework.writeControlFlowGraphs(solutions, RankDir.LEFT_TO_RIGHT);

--- a/src/main/java/nl/uu/cs/ape/sat/Main.java
+++ b/src/main/java/nl/uu/cs/ape/sat/Main.java
@@ -2,6 +2,7 @@ package nl.uu.cs.ape.sat;
 
 import guru.nidi.graphviz.attribute.RankDir;
 import nl.uu.cs.ape.sat.core.implSAT.SATsolutionsList;
+import nl.uu.cs.ape.sat.utils.APEConfigException;
 import nl.uu.cs.ape.sat.utils.APEUtils;
 import org.json.JSONException;
 
@@ -33,23 +34,25 @@ public class Main {
 
         APE apeFramework = null;
         try {
+
+            // set up the APE framework
             apeFramework = new APE(path);
-        } catch (JSONException e) {
-            System.err.println(e.getMessage());
-            return;
-        } catch (IOException e) {
-            System.err.println(e.getMessage());
-            return;
-        } catch (ExceptionInInitializerError e) {
+
+        } catch (APEConfigException | JSONException | IOException e) {
+            System.err.println("Error in setting up the APE framework:");
             System.err.println(e.getMessage());
             return;
         }
 
         SATsolutionsList solutions;
         try {
+
+            // run the synthesis and retrieve the solutions
             solutions = apeFramework.runSynthesis(path, apeFramework.getDomainSetup());
-        } catch (IOException e) {
-            System.err.println("Error in synthesis execution. Writing to the file system failed.");
+
+        } catch (APEConfigException | JSONException | IOException e) {
+            System.err.println("Error in synthesis execution:");
+            System.err.println(e.getMessage());
             return;
         }
 

--- a/src/main/java/nl/uu/cs/ape/sat/utils/APEConfigException.java
+++ b/src/main/java/nl/uu/cs/ape/sat/utils/APEConfigException.java
@@ -1,8 +1,20 @@
 package nl.uu.cs.ape.sat.utils;
 
+import org.json.JSONException;
+
+import java.io.IOException;
+
 /**
- * This Exception will be thrown if teh configuration is incorrect.
+ * This {@link APEConfigException} will be thrown if the configuration is incorrect.
  * Additional info will be provided to help the user fix the problem.
+ * The static methods in this class can also be used to throw other kinds of exceptions regarding the core- and run configuration.
+ * <p>
+ * The configuration problems can be classified in three exceptions:
+ * <ul>
+ *   <li>APEConfigException: Application specific configuration exceptions.</li>
+ *   <li>JSONException: Values or files that cannot be parsed to a value.</li>
+ *   <li>IOException: Errors in in reading from the file system.</li>
+ * </ul>
  */
 public class APEConfigException extends Exception {
 
@@ -47,20 +59,6 @@ public class APEConfigException extends Exception {
     }
 
     /**
-     * Cannot parse ape config exception.
-     *
-     * @param <T>          The type that APE cannot parse to.
-     * @param tag          Corresponding JSON tag in the configuration file.
-     * @param value        The value for the tag, provided by the user.
-     * @param expectedType The type that APE cannot parse to.
-     * @param info         Application specific information that may help the user solve the problem.
-     * @return Configuration exception with information that may help the user solve the problem.
-     */
-    public static <T> APEConfigException cannotParse(String tag, Object value, Class<T> expectedType, String info) {
-        return new APEConfigException(String.format("'%s' cannot be parsed to '%s' for tag '%s', %s", value, expectedType.getSimpleName(), tag, info));
-    }
-
-    /**
      * Missing tag ape config exception.
      *
      * @param tag Corresponding JSON tag in the configuration file.
@@ -71,14 +69,28 @@ public class APEConfigException extends Exception {
     }
 
     /**
+     * Cannot parse ape config exception.
+     *
+     * @param <T>          The type that APE cannot parse to.
+     * @param tag          Corresponding JSON tag in the configuration file.
+     * @param value        The value for the tag, provided by the user.
+     * @param expectedType The type that APE cannot parse to.
+     * @param info         Application specific information that may help the user solve the problem.
+     * @return Configuration exception with information that may help the user solve the problem.
+     */
+    public static <T> JSONException cannotParse(String tag, Object value, Class<T> expectedType, String info) {
+        return new JSONException(String.format("Value '%s' cannot be parsed to type '%s' for tag '%s', %s", value, expectedType.getSimpleName(), tag, info));
+    }
+
+    /**
      * Path not found ape config exception.
      *
      * @param tag  Corresponding JSON tag in the configuration file.
      * @param path The relative- or absolute path to a JSON- or OWL file.
      * @return Configuration exception with information that may help the user solve the problem.
      */
-    public static APEConfigException pathNotFound(String tag, String path) {
-        return new APEConfigException(String.format("Provided path '%s' for tag '%s' does not exist.", path, tag));
+    public static IOException pathNotFound(String tag, String path) {
+        return new IOException(String.format("Provided path '%s' for tag '%s' does not exist.", path, tag));
     }
 
     /**
@@ -89,7 +101,7 @@ public class APEConfigException extends Exception {
      * @param missingPermission The missing READ or WRITE permission for the file described by the path.
      * @return Configuration exception with information that may help the user solve the problem.
      */
-    public static APEConfigException missingPermission(String tag, String path, Object missingPermission) {
-        return new APEConfigException(String.format("You are missing [%s] permission for path '%s' for tag '%s'", missingPermission, path, tag));
+    public static IOException missingPermission(String tag, String path, Object missingPermission) {
+        return new IOException(String.format("You are missing [%s] permission for path '%s' for tag '%s'", missingPermission, path, tag));
     }
 }

--- a/src/main/java/nl/uu/cs/ape/sat/utils/APEConfigException.java
+++ b/src/main/java/nl/uu/cs/ape/sat/utils/APEConfigException.java
@@ -1,0 +1,95 @@
+package nl.uu.cs.ape.sat.utils;
+
+/**
+ * This Exception will be thrown if teh configuration is incorrect.
+ * Additional info will be provided to help the user fix the problem.
+ */
+public class APEConfigException extends Exception {
+
+    /**
+     * Instantiates a new Ape config exception.
+     *
+     * @param message The message that will be passed to the {@link Exception} super class.
+     */
+    public APEConfigException(String message) {
+        super(message);
+    }
+
+    /**
+     * Instantiates a new Ape config exception.
+     *
+     * @param message The message that will be passed to the {@link Exception} super class.
+     * @param cause   The cause of this exception.
+     */
+    public APEConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Instantiates a new Ape config exception.
+     *
+     * @param cause The cause of this exception.
+     */
+    public APEConfigException(Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+
+    /**
+     * Invalid value ape config exception.
+     *
+     * @param tag   Corresponding JSON tag in the configuration file.
+     * @param value The value for the tag, provided by the user.
+     * @param info  Application specific information that may help the user solve the problem.
+     * @return Configuration exception with information that may help the user solve the problem.
+     */
+    public static APEConfigException invalidValue(String tag, Object value, String info) {
+        return new APEConfigException(String.format("'%s' is not a valid value for tag '%s', %s", value, tag, info));
+    }
+
+    /**
+     * Cannot parse ape config exception.
+     *
+     * @param <T>          The type that APE cannot parse to.
+     * @param tag          Corresponding JSON tag in the configuration file.
+     * @param value        The value for the tag, provided by the user.
+     * @param expectedType The type that APE cannot parse to.
+     * @param info         Application specific information that may help the user solve the problem.
+     * @return Configuration exception with information that may help the user solve the problem.
+     */
+    public static <T> APEConfigException cannotParse(String tag, Object value, Class<T> expectedType, String info) {
+        return new APEConfigException(String.format("'%s' cannot be parsed to '%s' for tag '%s', %s", value, expectedType.getSimpleName(), tag, info));
+    }
+
+    /**
+     * Missing tag ape config exception.
+     *
+     * @param tag Corresponding JSON tag in the configuration file.
+     * @return Configuration exception with information that may help the user solve the problem.
+     */
+    public static APEConfigException missingTag(String tag) {
+        return new APEConfigException(String.format("Tag '%s' is not provided, cannot setup the configuration.", tag));
+    }
+
+    /**
+     * Path not found ape config exception.
+     *
+     * @param tag  Corresponding JSON tag in the configuration file.
+     * @param path The relative- or absolute path to a JSON- or OWL file.
+     * @return Configuration exception with information that may help the user solve the problem.
+     */
+    public static APEConfigException pathNotFound(String tag, String path) {
+        return new APEConfigException(String.format("Provided path '%s' for tag '%s' does not exist.", path, tag));
+    }
+
+    /**
+     * Missing permission ape config exception.
+     *
+     * @param tag               Corresponding JSON tag in the configuration file.
+     * @param path              The relative- or absolute path to a JSON- or OWL file.
+     * @param missingPermission The missing READ or WRITE permission for the file described by the path.
+     * @return Configuration exception with information that may help the user solve the problem.
+     */
+    public static APEConfigException missingPermission(String tag, String path, Object missingPermission) {
+        return new APEConfigException(String.format("You are missing [%s] permission for path '%s' for tag '%s'", missingPermission, path, tag));
+    }
+}

--- a/src/main/java/nl/uu/cs/ape/sat/utils/APEUtils.java
+++ b/src/main/java/nl/uu/cs/ape/sat/utils/APEUtils.java
@@ -792,4 +792,13 @@ public final class APEUtils {
 
         return abstractLabel.toString();
     }
+
+    /**
+     * Print a warning to the console for the user to see.
+     *
+     * @param warning The warning message.
+     */
+    public static void printWarning(String warning){
+        System.out.println("[WARNING] " + warning);
+    }
 }

--- a/src/main/java/nl/uu/cs/ape/sat/utils/Test.java
+++ b/src/main/java/nl/uu/cs/ape/sat/utils/Test.java
@@ -62,12 +62,13 @@ public class Test {
 
         APE apeFramework = null;
         try {
+
+            // set up the APE framework
             apeFramework = new APE(file.getAbsolutePath());
-        } catch (JSONException e) {
-            System.err.println("Error in parsing the configuration file.");
-            return null;
-        } catch (IOException e) {
-            System.err.println("Error in reading the configuration file.");
+
+        } catch (APEConfigException | JSONException | IOException e) {
+            System.err.println("Error in setting up the APE framework:");
+            System.err.println(e.getMessage());
             return null;
         }
 


### PR DESCRIPTION
- Added `APEConfigException` with static methods:
  - `invalidValue()`
  - `missingTag()`
  - `cannotParse()`
  - `pathNotFound()`
  - `missingPermission()`
  - can be thrown like: `throw APEConfigException.invalidValue(MAX_NOSOLUTIONS_TAG, -1, "use a numeric value greater or equal to 1.");` which results in the message: `'-1' is not a valid value for tag 'max_solutions', use a numeric value greater or equal to 1.`
- Altered / cleaned up `APEConfig`
  - Setup is more clear now and calls the following methods (these methods will throw relevant exceptions themselves with additional info):
    - `readPath()` (with read/write permission)
    - `readBooleanOrDefault()`
    - `readIntegerOrDefault()`
    - `getDataInstances()`
  - Getters for optional/obligatory core/run tags (mostly used to allow for easy testing)
  - Fixed Javadoc for methods