### PR TITLE
Tag validation

### DIFF
--- a/src/main/java/nl/uu/cs/ape/sat/APE.java
+++ b/src/main/java/nl/uu/cs/ape/sat/APE.java
@@ -4,6 +4,8 @@
 package nl.uu.cs.ape.sat;
 
 import guru.nidi.graphviz.attribute.Rank.RankDir;
+import nl.uu.cs.ape.sat.configuration.tags.validation.ValidationResult;
+import nl.uu.cs.ape.sat.configuration.tags.validation.ValidationResults;
 import nl.uu.cs.ape.sat.constraints.ConstraintTemplate;
 import nl.uu.cs.ape.sat.core.implSAT.SAT_SynthesisEngine;
 import nl.uu.cs.ape.sat.core.implSAT.SATsolutionsList;
@@ -271,6 +273,25 @@ public class APE {
         }
 
         return allSolutions;
+    }
+
+    /**
+     * Validates all the tags in a configuration object.
+     *
+     * @param config configuration file
+     * @return Results regarding the validations
+     */
+    public static ValidationResults validate(JSONObject config){
+        ValidationResults results = APECoreConfig.validate(config);
+        if(results.hasFails()){
+            return results;
+        }
+        try {
+            APE ape = new APE(config);
+            results.add(APERunConfig.validate(config, ape.getDomainSetup()));
+        } catch (IOException | OWLOntologyCreationException ignored) { }
+
+        return results;
     }
 
     /**

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/APECoreConfig.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/APECoreConfig.java
@@ -4,6 +4,7 @@ import nl.uu.cs.ape.sat.configuration.tags.APEConfigTag;
 import nl.uu.cs.ape.sat.configuration.tags.APEConfigTagFactory;
 import nl.uu.cs.ape.sat.configuration.tags.APEConfigTagFactory.TAGS.*;
 import nl.uu.cs.ape.sat.configuration.tags.APEConfigTags;
+import nl.uu.cs.ape.sat.configuration.tags.validation.ValidationResults;
 import nl.uu.cs.ape.sat.utils.APEUtils;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
@@ -179,6 +180,23 @@ public class APECoreConfig {
         for (APEConfigTag<?> tag : all_tags) {
             tag.setValue(coreConfiguration);
         }
+    }
+
+    private APECoreConfig(){}
+
+    public static ValidationResults validate(JSONObject json){
+        APECoreConfig dummy = new APECoreConfig();
+        ValidationResults results = new ValidationResults();
+        for(APEConfigTag<?> tag : dummy.all_tags){
+            results.add(tag.validate(json));
+            if(results.fail()){
+                return results;
+            }
+            else{
+                tag.setValue(json); // for dependencies
+            }
+        }
+        return results;
     }
 
     /**

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/APECoreConfig.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/APECoreConfig.java
@@ -189,7 +189,7 @@ public class APECoreConfig {
         ValidationResults results = new ValidationResults();
         for(APEConfigTag<?> tag : dummy.all_tags){
             results.add(tag.validate(json));
-            if(results.fail()){
+            if(results.hasFails()){
                 return results;
             }
             else{

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/APERunConfig.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/APERunConfig.java
@@ -5,6 +5,7 @@ import nl.uu.cs.ape.sat.configuration.tags.APEConfigTag;
 import nl.uu.cs.ape.sat.configuration.tags.APEConfigTagFactory;
 import nl.uu.cs.ape.sat.configuration.tags.APEConfigTagFactory.TAGS.*;
 import nl.uu.cs.ape.sat.configuration.tags.APEConfigTags;
+import nl.uu.cs.ape.sat.configuration.tags.validation.ValidationResults;
 import nl.uu.cs.ape.sat.models.DataInstance;
 import nl.uu.cs.ape.sat.models.Range;
 import nl.uu.cs.ape.sat.models.enums.ConfigEnum;
@@ -160,6 +161,25 @@ public class APERunConfig {
         setDebugMode(builder.debugMode);
         setProgramInputs(builder.programInputs);
         setProgramOutputs(builder.programOutputs);
+    }
+
+    private APERunConfig(APEDomainSetup setup){
+        this.apeDomainSetup = setup;
+    }
+
+    public static ValidationResults validate(JSONObject json, APEDomainSetup setup){
+        APERunConfig dummy = new APERunConfig(setup);
+        ValidationResults results = new ValidationResults();
+        for(APEConfigTag<?> tag : dummy.all_tags){
+            results.add(tag.validate(json));
+            if(results.fail()){
+                return results;
+            }
+            else{
+                tag.setValue(json); // for dependencies
+            }
+        }
+        return results;
     }
 
     /**

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/APERunConfig.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/APERunConfig.java
@@ -172,7 +172,7 @@ public class APERunConfig {
         ValidationResults results = new ValidationResults();
         for(APEConfigTag<?> tag : dummy.all_tags){
             results.add(tag.validate(json));
-            if(results.fail()){
+            if(results.hasFails()){
                 return results;
             }
             else{

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTag.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTag.java
@@ -42,7 +42,7 @@ public abstract class APEConfigTag<T> {
 
         final ValidationResults results = validate(obj);
 
-        if (results.fail()) {
+        if (results.hasFails()) {
             throw APEConfigException.ruleViolations(results);
         }
 
@@ -55,7 +55,7 @@ public abstract class APEConfigTag<T> {
 
         final ValidationResults results = validate(value);
 
-        if (results.fail()) {
+        if (results.hasFails()) {
             throw APEConfigException.ruleViolations(results);
         }
 

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTag.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTag.java
@@ -46,7 +46,9 @@ public abstract class APEConfigTag<T> {
             throw APEConfigException.ruleViolations(results);
         }
 
-        this.value = constructFromJSON(obj);
+        if(obj.has(getTagName())){
+            this.value = constructFromJSON(obj);
+        }
     }
 
     public void setValue(T value) {
@@ -84,7 +86,7 @@ public abstract class APEConfigTag<T> {
         try {
             final T dummy = constructFromJSON(json);
             results.add(validate(dummy));
-        } catch (JSONException | APEConfigException e) {
+        } catch (JSONException | APEConfigException | IllegalArgumentException e) {
             results.add(getTagName(), e.getMessage(), false);
         }
 
@@ -150,6 +152,10 @@ public abstract class APEConfigTag<T> {
             }
 
             return json;
+        }
+
+        public String getTagName(){
+            return tag_name;
         }
     }
 }

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTagFactory.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTagFactory.java
@@ -78,7 +78,8 @@ public class APEConfigTagFactory {
             }
 
             @Override
-            protected ValidationResults validate(List<String> value, String dependency1, ValidationResults results) {
+            protected ValidationResults validate(List<String> value, String ontology_prefix, ValidationResults results) {
+                // TODO
                 return results;
             }
 
@@ -87,11 +88,6 @@ public class APEConfigTagFactory {
                 return DATA_DIMENSIONS;
             }
 
-            @Override
-            protected ValidationResults validate(List<String> dimensions, ValidationResults results) {
-                // TODO: Check dimensions ?
-                return results;
-            }
         }
 
         public static abstract class DataInstances extends APEConfigDependentTag.One<List<DataInstance>, APEDomainSetup> {

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/validation/ValidationResult.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/validation/ValidationResult.java
@@ -2,33 +2,70 @@ package nl.uu.cs.ape.sat.configuration.tags.validation;
 
 import org.json.JSONObject;
 
+/**
+ * This class contains information about the outcome of a validation.
+ * More specifically: the tag name that was being tested, the description of the rule
+ * and a boolean that represents a success or fail.
+ */
 public class ValidationResult {
 
     private final String tag, ruleDescription;
     private final boolean success;
 
+    /**
+     * Instantiates a new Validation result.
+     *
+     * @param tag             The tag name that was being tested.
+     * @param ruleDescription The description of the rule.
+     * @param success         Represents a success or fail.
+     */
     public ValidationResult(String tag, String ruleDescription, boolean success) {
         this.tag = tag;
         this.success = success;
         this.ruleDescription = ruleDescription;
     }
 
+    /**
+     * Gets the tag name that was being tested.
+     *
+     * @return the tag
+     */
     public String getTag() {
         return this.tag;
     }
 
+    /**
+     * Result is a success.
+     *
+     * @return success
+     */
     public boolean isSuccess() {
         return this.success;
     }
 
+    /**
+     * Result is a fail.
+     *
+     * @return fail
+     */
     public boolean isFail() {
         return !this.success;
     }
 
+    /**
+     * Gets rule description.
+     *
+     * @return the rule description
+     */
     public String getRuleDescription() {
         return this.ruleDescription;
     }
 
+    /**
+     * To JSONObject.
+     *
+     * @return the json object containing the tags: "tag", "description" and "success"
+     */
     public JSONObject toJSON() {
         return new JSONObject()
                 .put("tag", getTag())

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/validation/ValidationResults.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/validation/ValidationResults.java
@@ -52,11 +52,15 @@ public class ValidationResults {
     }
 
     public JSONArray toJSONArray() {
-        return new JSONArray(results.stream().map(ValidationResult::toJSON));
+        return new JSONArray(results.stream().map(ValidationResult::toJSON).collect(Collectors.toList()));
     }
 
     public Stream<ValidationResult> stream() {
         return results.stream();
     }
 
+    @Override
+    public String toString() {
+        return toJSONArray().toString(2);
+    }
 }

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/validation/ValidationResults.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/validation/ValidationResults.java
@@ -8,57 +8,111 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * A container for validation results for all tags.
+ */
 public class ValidationResults {
 
     private final List<ValidationResult> results = new ArrayList<>();
 
+    /**
+     * Instantiates a new empty container.
+     */
     public ValidationResults() {
     }
 
+    /**
+     * Instantiates a new container based on an existing collection.
+     *
+     * @param results an existing collection of validation results
+     */
     public ValidationResults(Collection<ValidationResult> results) {
         this.results.addAll(results);
     }
 
+    /**
+     * Gets a copy of the validation results in List format.
+     *
+     * @return a copy of the validation results in List format
+     */
+    public List<ValidationResult> list() {
+        return new ArrayList<>(this.results);
+    }
+
+    /**
+     * Gets a copy of the validation results in Stream format.
+     *
+     * @return a copy of the validation results in Stream format
+     */
+    public Stream<ValidationResult> stream() {
+        return new ArrayList<>(this.results).stream();
+    }
+
+    /**
+     * Add a new validation result.
+     * The container will call the ValidationResult constructor.
+     *
+     * @param tag             The tag name that was being tested.
+     * @param ruleDescription The description of the rule.
+     * @param success         Represents a success or fail.
+     */
     public void add(String tag, String ruleDescription, boolean success) {
         results.add(new ValidationResult(tag, ruleDescription, success));
     }
 
+    /**
+     * Add an existing container to this container.
+     *
+     * @param results an existing container
+     */
     public void add(ValidationResults results) {
-        this.results.addAll(results.toList());
+        this.results.addAll(results.list());
     }
 
-    public List<ValidationResult> toList() {
-        return new ArrayList<>(this.results);
-    }
-
-    public ValidationResults getFails() {
-        return new ValidationResults(this.results.stream()
+    /**
+     * Gets all the ValidationResults that fail.
+     *
+     * @return all the ValidationResults that fail
+     */
+    public List<ValidationResult> getFails() {
+        return this.results.stream()
                 .filter(ValidationResult::isFail)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
     }
 
-    public boolean fail() {
+    /**
+     * Gets all the ValidationResults that succeed.
+     *
+     * @return all the ValidationResults that succeed
+     */
+    public List<ValidationResult> getSuccesses() {
+        return this.results.stream()
+                .filter(ValidationResult::isSuccess)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Indicates whether this class contains at least one fail.
+     *
+     * @return a boolean indicating whether this class contains at least one fail
+     */
+    public boolean hasFails() {
         return results.stream().anyMatch(ValidationResult::isFail);
     }
 
-    public boolean success() {
-        return results.stream().allMatch(ValidationResult::isSuccess);
-    }
-
-    public ValidationResults getSuccesses() {
-        return new ValidationResults(this.results.stream()
-                .filter(ValidationResult::isSuccess)
-                .collect(Collectors.toList()));
-    }
-
+    /**
+     * Mapping the list to JSONArray using {@link ValidationResult#toJSON()}.
+     *
+     * @return a JSONArray
+     */
     public JSONArray toJSONArray() {
         return new JSONArray(results.stream().map(ValidationResult::toJSON).collect(Collectors.toList()));
     }
 
-    public Stream<ValidationResult> stream() {
-        return results.stream();
-    }
-
+    /**
+     * Override toString as a JSON
+     * @return String representation
+     */
     @Override
     public String toString() {
         return toJSONArray().toString(2);

--- a/src/main/java/nl/uu/cs/ape/sat/utils/APEUtils.java
+++ b/src/main/java/nl/uu/cs/ape/sat/utils/APEUtils.java
@@ -871,4 +871,7 @@ public final class APEUtils {
         System.setErr(original);
     }
 
+    public static JSONObject clone(JSONObject original){
+        return new JSONObject(original, JSONObject.getNames(original));
+    }
 }

--- a/src/test/java/nl/uu/cs/ape/sat/ape/CLITest.java
+++ b/src/test/java/nl/uu/cs/ape/sat/ape/CLITest.java
@@ -36,12 +36,12 @@ public class CLITest {
     public void run(String base_config_path, String ontology_path, String tools_path, String constraints_path, String solution_dir_path){
 
         // get the base configuration file
-        final JSONObject config_content = TestResources.getJSONResource(base_config_path)
-                // add paths to the other files to the configuration
-                .put("ontology_path", TestResources.getAbsoluteResourcePath(ontology_path))
-                .put("tool_annotations_path", TestResources.getAbsoluteResourcePath(tools_path))
-                .put("constraints_path", TestResources.getAbsoluteResourcePath(constraints_path))
-                .put("solutions_dir_path", TestResources.getAbsoluteResourcePath(solution_dir_path));
+        final JSONObject config_content = TestResources.getConfigResource(
+                base_config_path,
+                ontology_path,
+                tools_path,
+                constraints_path,
+                solution_dir_path);
 
         // create a new configuration file
         final String config_path = TestResources.writeFile(Paths.get(Objects.requireNonNull(TestResources.getAbsoluteResourcePath(solution_dir_path))).resolve("config.json").toAbsolutePath().toString(), config_content.toString(2));

--- a/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTagTest.java
+++ b/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTagTest.java
@@ -1,15 +1,30 @@
 package nl.uu.cs.ape.sat.configuration;
 
+import nl.uu.cs.ape.sat.APE;
 import nl.uu.cs.ape.sat.configuration.tags.APEConfigTag;
+import nl.uu.cs.ape.sat.configuration.tags.APEConfigTags;
+import nl.uu.cs.ape.sat.configuration.tags.validation.ValidationResults;
+import nl.uu.cs.ape.sat.utils.APEDomainSetup;
 import nl.uu.cs.ape.sat.utils.APEUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import util.TestResources;
+
+import javax.inject.Provider;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import static util.Evaluation.success;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class APEConfigTagTest {
 
     @Test
-    public void test(){
+    public void infoOutputTest(){
 
         System.out.println("Test type tags..");
 
@@ -18,11 +33,125 @@ public class APEConfigTagTest {
             if(tag.type == APEConfigTag.TagType.INTEGER){
                 System.out.printf("Web API shows `%s` box for tag `%s`, with min:`%s` and max:`%s`\n",tag.type, tag.label, tag.constraints.getInt("min"), tag.constraints.getInt("max"));
             }
-
         }
 
         System.out.printf("\n### Display all tag info ####\nCORE:\n%s\n\nRUN:\n%s\n",
                 APECoreConfig.getTags().toJSON().toString(3),
                 APERunConfig.getTags().toJSON().toString(3));
     }
+
+    @Test
+    public void coreValidationTest(){
+        final JSONObject correct_config = TestResources.getJSONResource("cli/gmt/base_config.json")
+                // add paths to the other files to the configuration
+                .put("ontology_path", TestResources.getAbsoluteResourcePath("cli/gmt/GMT_UseCase_taxonomy.owl"))
+                .put("tool_annotations_path", TestResources.getAbsoluteResourcePath("cli/gmt/tool_annotations.json"))
+                .put("constraints_path", TestResources.getAbsoluteResourcePath("cli/gmt/constraints_e0.json"))
+                .put("solutions_dir_path", TestResources.getAbsoluteResourcePath("cli/gmt"));
+
+        ValidationResults results = APECoreConfig.validate(correct_config);
+
+        assertTrue(results.success());
+
+        /* Test missing obligatory tag  */
+        List<String> tags = APECoreConfig.getTags().getObligatory().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        for(String tag : tags){
+
+            JSONObject altered_config = APEUtils.clone(correct_config);
+            altered_config.remove(tag);
+
+            results = APECoreConfig.validate(altered_config);
+
+            assertFalse(results.success());
+            assertTrue(results.stream().anyMatch(result -> result.isFail() && result.getTag().equals(tag)));
+
+            success("CoreConfig is missing an obligatory tag -> %s", results.getFails().toList().get(0).toJSON().toString());
+        }
+
+        /* Test missing optional tag  */
+        tags = APECoreConfig.getTags().getOptional().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        for(String tag : tags){
+
+            JSONObject altered_config = APEUtils.clone(correct_config);
+            altered_config.remove(tag);
+
+            results = APECoreConfig.validate(altered_config);
+
+            assertTrue(results.success());
+        }
+
+        /* Test incorrect tag  */
+        tags = APECoreConfig.getTags().getAll().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        for(String tag : tags){
+
+            JSONObject altered_config = APEUtils.clone(correct_config)
+                    .put(tag, "");
+
+            results = APECoreConfig.validate(altered_config);
+
+            assertFalse(results.success());
+            assertTrue(results.stream().anyMatch(result -> result.isFail() && result.getTag().equals(tag)));
+
+            success("CoreConfig contains an incorrect tag -> %s", results.getFails().toList().get(0).toJSON().toString());
+        }
+    }
+
+    @Test
+    public void runValidationTest() throws IOException, OWLOntologyCreationException {
+        final JSONObject correct_config = TestResources.getJSONResource("cli/gmt/base_config.json")
+                // add paths to the other files to the configuration
+                .put("ontology_path", TestResources.getAbsoluteResourcePath("cli/gmt/GMT_UseCase_taxonomy.owl"))
+                .put("tool_annotations_path", TestResources.getAbsoluteResourcePath("cli/gmt/tool_annotations.json"))
+                .put("constraints_path", TestResources.getAbsoluteResourcePath("cli/gmt/constraints_e0.json"))
+                .put("solutions_dir_path", TestResources.getAbsoluteResourcePath("cli/gmt"));
+
+        APEDomainSetup domainSetup = new APE(correct_config).getDomainSetup();
+
+        ValidationResults results = APERunConfig.validate(correct_config, domainSetup);
+
+        assertTrue(results.success());
+
+        /* Test missing obligatory tag  */
+        List<String> tags = APERunConfig.getTags().getObligatory().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        for(String tag : tags){
+
+            JSONObject altered_config = APEUtils.clone(correct_config);
+            altered_config.remove(tag);
+
+            results = APERunConfig.validate(altered_config, domainSetup);
+
+            assertFalse(results.success());
+            assertTrue(results.stream().anyMatch(result -> result.isFail() && result.getTag().equals(tag)));
+
+            success("RunConfig is missing an obligatory tag -> %s", results.getFails().toList().get(0).toJSON().toString());
+        }
+
+        /* Test missing optional tag  */
+        tags = APERunConfig.getTags().getOptional().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        for(String tag : tags){
+
+            JSONObject altered_config = APEUtils.clone(correct_config);
+            altered_config.remove(tag);
+
+            results = APERunConfig.validate(altered_config, domainSetup);
+
+            assertTrue(results.success());
+        }
+
+        /* Test incorrect tag  */
+        tags = APERunConfig.getTags().getAll().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        for(String tag : tags){
+
+            JSONObject altered_config = APEUtils.clone(correct_config)
+                    .put(tag, "");
+
+            results = APERunConfig.validate(altered_config, domainSetup);
+
+            assertFalse(results.success());
+            assertTrue(results.stream().anyMatch(result -> result.isFail() && result.getTag().equals(tag)));
+
+            success("RunConfig contains an incorrect tag -> %s", results.getFails().toList().get(0).toJSON().toString());
+        }
+    }
+
 }

--- a/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTagTest.java
+++ b/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTagTest.java
@@ -2,36 +2,33 @@ package nl.uu.cs.ape.sat.configuration;
 
 import nl.uu.cs.ape.sat.APE;
 import nl.uu.cs.ape.sat.configuration.tags.APEConfigTag;
-import nl.uu.cs.ape.sat.configuration.tags.APEConfigTags;
 import nl.uu.cs.ape.sat.configuration.tags.validation.ValidationResults;
 import nl.uu.cs.ape.sat.utils.APEDomainSetup;
 import nl.uu.cs.ape.sat.utils.APEUtils;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import util.TestResources;
 
-import javax.inject.Provider;
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import static util.Evaluation.success;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static util.Evaluation.success;
 
 public class APEConfigTagTest {
 
     @Test
-    public void infoOutputTest(){
+    public void infoOutputTest() {
 
         System.out.println("Test type tags..");
 
-        for(APEConfigTag.Info<?> tag : APERunConfig.getTags().getAll()){
+        for (APEConfigTag.Info<?> tag : APERunConfig.getTags().getAll()) {
 
-            if(tag.type == APEConfigTag.TagType.INTEGER){
-                System.out.printf("Web API shows `%s` box for tag `%s`, with min:`%s` and max:`%s`\n",tag.type, tag.label, tag.constraints.getInt("min"), tag.constraints.getInt("max"));
+            if (tag.type == APEConfigTag.TagType.INTEGER) {
+                System.out.printf("Web API shows `%s` box for tag `%s`, with min:`%s` and max:`%s`\n", tag.type, tag.label, tag.constraints.getInt("min"), tag.constraints.getInt("max"));
             }
         }
 
@@ -41,7 +38,7 @@ public class APEConfigTagTest {
     }
 
     @Test
-    public void coreValidationTest(){
+    public void coreValidationTest() {
         final JSONObject correct_config = TestResources.getJSONResource("cli/gmt/base_config.json")
                 // add paths to the other files to the configuration
                 .put("ontology_path", TestResources.getAbsoluteResourcePath("cli/gmt/GMT_UseCase_taxonomy.owl"))
@@ -51,48 +48,48 @@ public class APEConfigTagTest {
 
         ValidationResults results = APECoreConfig.validate(correct_config);
 
-        assertTrue(results.success());
+        assertFalse(results.hasFails());
 
         /* Test missing obligatory tag  */
         List<String> tags = APECoreConfig.getTags().getObligatory().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
-        for(String tag : tags){
+        for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
             altered_config.remove(tag);
 
             results = APECoreConfig.validate(altered_config);
 
-            assertFalse(results.success());
+            assertTrue(results.hasFails());
             assertTrue(results.stream().anyMatch(result -> result.isFail() && result.getTag().equals(tag)));
 
-            success("CoreConfig is missing an obligatory tag -> %s", results.getFails().toList().get(0).toJSON().toString());
+            success("CoreConfig is missing an obligatory tag -> %s", results.getFails().get(0).toJSON().toString());
         }
 
         /* Test missing optional tag  */
         tags = APECoreConfig.getTags().getOptional().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
-        for(String tag : tags){
+        for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
             altered_config.remove(tag);
 
             results = APECoreConfig.validate(altered_config);
 
-            assertTrue(results.success());
+            assertFalse(results.hasFails());
         }
 
         /* Test incorrect tag  */
         tags = APECoreConfig.getTags().getAll().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
-        for(String tag : tags){
+        for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config)
                     .put(tag, "");
 
             results = APECoreConfig.validate(altered_config);
 
-            assertFalse(results.success());
+            assertTrue(results.hasFails());
             assertTrue(results.stream().anyMatch(result -> result.isFail() && result.getTag().equals(tag)));
 
-            success("CoreConfig contains an incorrect tag -> %s", results.getFails().toList().get(0).toJSON().toString());
+            success("CoreConfig contains an incorrect tag -> %s", results.getFails().get(0).toJSON().toString());
         }
     }
 
@@ -109,48 +106,48 @@ public class APEConfigTagTest {
 
         ValidationResults results = APERunConfig.validate(correct_config, domainSetup);
 
-        assertTrue(results.success());
+        assertFalse(results.hasFails());
 
         /* Test missing obligatory tag  */
         List<String> tags = APERunConfig.getTags().getObligatory().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
-        for(String tag : tags){
+        for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
             altered_config.remove(tag);
 
             results = APERunConfig.validate(altered_config, domainSetup);
 
-            assertFalse(results.success());
+            assertTrue(results.hasFails());
             assertTrue(results.stream().anyMatch(result -> result.isFail() && result.getTag().equals(tag)));
 
-            success("RunConfig is missing an obligatory tag -> %s", results.getFails().toList().get(0).toJSON().toString());
+            success("RunConfig is missing an obligatory tag -> %s", results.getFails().get(0).toJSON().toString());
         }
 
         /* Test missing optional tag  */
         tags = APERunConfig.getTags().getOptional().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
-        for(String tag : tags){
+        for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
             altered_config.remove(tag);
 
             results = APERunConfig.validate(altered_config, domainSetup);
 
-            assertTrue(results.success());
+            assertFalse(results.hasFails());
         }
 
         /* Test incorrect tag  */
         tags = APERunConfig.getTags().getAll().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
-        for(String tag : tags){
+        for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config)
                     .put(tag, "");
 
             results = APERunConfig.validate(altered_config, domainSetup);
 
-            assertFalse(results.success());
+            assertTrue(results.hasFails());
             assertTrue(results.stream().anyMatch(result -> result.isFail() && result.getTag().equals(tag)));
 
-            success("RunConfig contains an incorrect tag -> %s", results.getFails().toList().get(0).toJSON().toString());
+            success("RunConfig contains an incorrect tag -> %s", results.getFails().get(0).toJSON().toString());
         }
     }
 

--- a/src/test/java/util/TestResources.java
+++ b/src/test/java/util/TestResources.java
@@ -1,5 +1,6 @@
 package util;
 
+import nl.uu.cs.ape.sat.Main;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 
@@ -94,5 +95,14 @@ public class TestResources {
             e.printStackTrace();
         }
         return absolutePath.toString();
+    }
+
+    public static JSONObject getConfigResource(String base_config_path, String ontology_path, String tools_path, String constraints_path, String solution_dir_path){
+        return getJSONResource(base_config_path)
+                // add paths to the other files to the configuration
+                .put("ontology_path", getAbsoluteResourcePath(ontology_path))
+                .put("tool_annotations_path", getAbsoluteResourcePath(tools_path))
+                .put("constraints_path", getAbsoluteResourcePath(constraints_path))
+                .put("solutions_dir_path", getAbsoluteResourcePath(solution_dir_path));
     }
 }


### PR DESCRIPTION
Added:
- Static validation functions for APECoreConfig and APERunConfig
- ValidationResult(s) javadoc
- Fixed bug: While not providing an optional tag, APE would still produced an error

TODO:
 - All other Javadoc

Example how to use `ValidationResults`:
``` java
public void demo(JSONObject config){
            
   ValidationResults results = APECoreConfig.validate(config);

   if(results.hasFails()){
      System.out.println(results.getFails().get(0).toString());
      return;
   }

   // safe operation, since validating the tags produced no failures
   APE framework = new APE(config);
            
   results = APERunConfig.validate(json, framework.getDomainSetup());

   if(results.hasFails()){
      System.out.println(results.getFails().get(0).toString());
      return;
   }

   // safe operation, since validating the tags produced no failures 
   SATsolutionsList solutions = framework.runSynthesis(config);
}
```

A Validation result could look like this:
``` json
{
   "success": false,
   "description": "The OWL object label cannot be an empty String.",
   "tag": "toolsTaxonomyRoot"
}
```