### PR TITLE
Javadoc + cleaning code

### DIFF
--- a/src/main/java/nl/uu/cs/ape/sat/APE.java
+++ b/src/main/java/nl/uu/cs/ape/sat/APE.java
@@ -277,9 +277,12 @@ public class APE {
 
     /**
      * Validates all the tags in a configuration object.
+     * If {@link ValidationResults#success()} ()} returns true,
+     * the configuration object can be safely used to setup the
+     * the APE framework and create an APERunConfiguration.
      *
      * @param config configuration file
-     * @return Results regarding the validations
+     * @return the validation results
      */
     public static ValidationResults validate(JSONObject config){
         ValidationResults results = APECoreConfig.validate(config);

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/APEConfigException.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/APEConfigException.java
@@ -1,6 +1,5 @@
 package nl.uu.cs.ape.sat.configuration;
 
-import nl.uu.cs.ape.sat.configuration.tags.validation.ValidationResult;
 import nl.uu.cs.ape.sat.configuration.tags.validation.ValidationResults;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -78,6 +77,15 @@ public class APEConfigException extends RuntimeException {
         return new JSONException(String.format("Value '%s' cannot be parsed to type '%s' for tag '%s', %s", value, expectedType.getSimpleName(), tag, info));
     }
 
+    /**
+     * Required validation tag json exception.
+     *
+     * @param <T>         the type parameter
+     * @param tag         the tag
+     * @param requiredTag the required tag
+     * @param info        the info
+     * @return the json exception
+     */
     public static <T> JSONException requiredValidationTag(String tag, String requiredTag, String info) {
         return new JSONException(String.format("Cannot parse tag '%s' without '%s', %s", tag, requiredTag, info));
     }
@@ -105,16 +113,6 @@ public class APEConfigException extends RuntimeException {
     }
 
     /**
-     * Path is found, but it is not a file.
-     *
-     * @param path The relative- or absolute path to a JSON- or OWL file.
-     * @return Configuration exception with information that may help the user solve the problem.
-     */
-    public static IOException notAFile(String path) {
-        return new IOException(String.format("Provided path '%s' is not a file.", path));
-    }
-
-    /**
      * Path is found, but it is not a directory.
      *
      * @param tag  Corresponding JSON tag in the configuration file.
@@ -138,29 +136,16 @@ public class APEConfigException extends RuntimeException {
     }
 
     /**
-     * Missing permission ape config exception.
+     * List all the failed validation criteria in one exception.
      *
-     * @param path              The relative- or absolute path to a JSON- or OWL file.
-     * @param missingPermission The missing READ or WRITE permission for the file described by the path.
-     * @return Configuration exception with information that may help the user solve the problem.
+     * @param validationResults the validation results
+     * @return the json exception
      */
-    public static IOException missingPermission(String path, Object missingPermission) {
-        return new IOException(String.format("You are missing [%s] permission for path '%s' for ", missingPermission, path));
-    }
-
-    public static JSONException fieldNotSpecified(String tag, String type) {
-        return new JSONException(String.format("No '%s' value provided for tag '%s'.", type, tag));
-    }
-
-    public static JSONException ruleViolation(ValidationResult result) {
-        return new JSONException(String.format("Tag '%s' is incorrect. %s", result.getTag(), result.getRuleDescription()));
-    }
-
-    public static JSONException ruleViolations(ValidationResults validationResults) {
+    public static APEConfigException ruleViolations(ValidationResults validationResults) {
         StringBuilder sb = new StringBuilder();
-        validationResults.getFails().stream().forEach(fail -> {
-            sb.append(String.format("Tag '%s' is incorrect: %s\n", fail.getTag(), fail.getRuleDescription()));
-        });
-        return new JSONException(sb.toString());
+        validationResults.getFails().forEach(fail ->
+                sb.append(String.format("Tag '%s' is incorrect: %s\n", fail.getTag(), fail.getRuleDescription()))
+        );
+        return new APEConfigException(sb.toString());
     }
 }

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/APECoreConfig.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/APECoreConfig.java
@@ -23,17 +23,6 @@ import java.util.stream.Collectors;
  * @author Vedran Kasalica
  */
 public class APECoreConfig {
-
-    /**
-     * Static versions of the Tags specified in this class. Should be in correct order for the Web API.
-     */
-    private static final APEConfigTags tag_info = new APEConfigTags(
-            new ONTOLOGY_PREFIX(),
-            new ONTOLOGY(),
-            new TOOL_ONTOLOGY_ROOT(null),
-            new DIMENSIONS_ONTOLOGY(null),
-            new TOOL_ANNOTATIONS()
-    );
     /**
      * The taxonomy (ontology) file
      */
@@ -54,6 +43,7 @@ public class APECoreConfig {
      * The JSON file with all tool annotations.
      */
     public final APEConfigTag<Path> TOOL_ANNOTATIONS = new APEConfigTagFactory.TAGS.TOOL_ANNOTATIONS();
+
     /**
      * All the Tags specified in this class. Should be in correct order of dependencies.
      */
@@ -64,6 +54,18 @@ public class APECoreConfig {
             this.DIMENSIONS_ONTOLOGY,
             this.TOOL_ANNOTATIONS
     };
+
+    /**
+     * Static versions of the Tags specified in this class.
+     * Should be in correct order for the Web API.
+     */
+    public static final APEConfigTags TAGS = new APEConfigTags(
+            new ONTOLOGY_PREFIX(),
+            new ONTOLOGY(),
+            new TOOL_ONTOLOGY_ROOT(null),
+            new DIMENSIONS_ONTOLOGY(null),
+            new TOOL_ANNOTATIONS()
+    );
 
     /**
      * Initialize the configuration of the project.
@@ -120,11 +122,6 @@ public class APECoreConfig {
      * @throws APEConfigException Error in setting up the the configuration.
      */
     public APECoreConfig(JSONObject configObject) throws JSONException, APEConfigException {
-
-        if (configObject == null) {
-            throw new NullPointerException("The provided JSONObject is null.");
-        }
-
         coreConfigSetup(configObject);
     }
 
@@ -156,10 +153,6 @@ public class APECoreConfig {
         }
     }
 
-    public static APEConfigTags getTags() {
-        return tag_info;
-    }
-
     /**
      * Setting up the core configuration of the library.
      * <p>
@@ -182,8 +175,21 @@ public class APECoreConfig {
         }
     }
 
+    /**
+     * Private constructor used by {@link APECoreConfig#validate(JSONObject config)}
+     * to create an empty instance.
+     */
     private APECoreConfig(){}
 
+    /**
+     * Validate tje JSONObject for each CORE tag.
+     * If {@link ValidationResults#success()} ()} returns true,
+     * the configuration object can be safely used to create
+     * an APECoreConfig object.
+     *
+     * @param json the json
+     * @return the validation results
+     */
     public static ValidationResults validate(JSONObject json){
         APECoreConfig dummy = new APECoreConfig();
         ValidationResults results = new ValidationResults();
@@ -234,12 +240,6 @@ public class APECoreConfig {
     public List<String> getDataDimensionRoots() {
         return DIMENSIONS_ONTOLOGY.getValue();
     }
-
-    /*
-     * Tags separated in the categories: obligatory, optional, core and run.
-     * The obligatory tags are used in the constructor to check the presence of tags.
-     * Optional tags or All tags are mostly used by test cases.
-     */
 
     /**
      * Gets tool annotations path.

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/APERunConfig.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/APERunConfig.java
@@ -334,6 +334,8 @@ public class APERunConfig {
     /**
      * Get the path of the relative path in solution_dir_path.
      *
+     * @param relativePath the relative path
+     *
      * @return absolute path of the relative path in solution_dir_path
      */
     public Path getSolutionDirPath2(String relativePath) {
@@ -348,7 +350,7 @@ public class APERunConfig {
     /**
      * Get the path to the directory where the executable scripts corresponding to the given solutions should be stored.
      *
-     * @return
+     * @return the path to the directory where the executable scripts corresponding to the given solutions should be stored
      */
     public Path getSolutionDirPath2Executables() {
         return getSolutionDirPath2(EXECUTABLES_FOLDER_NAME);
@@ -358,7 +360,7 @@ public class APERunConfig {
     /**
      * Get the path to the directory where the graphs representation of the solutions should be stored.
      *
-     * @return
+     * @return the path to the directory where the graphs representation of the solutions should be stored
      */
     public Path getSolutionDirPath2Figures() {
         return getSolutionDirPath2(FIGURES_FOLDER_NAME);
@@ -510,6 +512,7 @@ public class APERunConfig {
 
     /**
      * @param solutionMinLength the solutionMinLength to set
+     * @param solutionMaxLength the solutionMaxLength to set
      */
     public void setSolutionLength(int solutionMinLength, int solutionMaxLength) {
         this.SOLUTION_LENGTH_RANGE.setValue(Range.of(solutionMinLength, solutionMaxLength));
@@ -527,8 +530,6 @@ public class APERunConfig {
 
     /**
      * Creates builder to build {@link APERunConfig}.
-     *
-     * @return created builder
      */
     public interface ISolutionMinLengthStage {
         ISolutionMaxLengthStage withSolutionMinLength(int solutionMinLength);

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/APERunConfig.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/APERunConfig.java
@@ -26,26 +26,6 @@ import java.util.List;
  * @author Vedran Kasalica
  */
 public class APERunConfig {
-
-    /**
-     * Static versions of the Tags specified in this class. Should be in correct order for the Web API.
-     */
-    private static final APEConfigTags tag_info = new APEConfigTags(
-            new CONSTRAINTS(),
-            new SHARED_MEMORY(),
-            new SOLUTION_DIR_PATH(),
-            new SOLUTION_LENGTH_RANGE(),
-            new MAX_NO_SOLUTIONS(),
-            new NO_EXECUTIONS(),
-            new NO_GRAPHS(),
-            new USE_WORKFLOW_INPUT(),
-            new USE_ALL_GENERATED_DATA(),
-            new DEBUG_MODE(),
-            new TOOL_SEQ_REPEAT(),
-            new PROGRAM_OUTPUTS(null),
-            new PROGRAM_INPUTS(null)
-    );
-
     /**
      * Path to the file with all workflow constraints.
      */
@@ -130,6 +110,26 @@ public class APERunConfig {
             this.PROGRAM_OUTPUTS,
             this.PROGRAM_INPUTS
     };
+
+    /**
+     * Static versions of the Tags specified in this class. Should be in correct order for the Web API.
+     */
+    public static final APEConfigTags TAGS = new APEConfigTags(
+            new CONSTRAINTS(),
+            new SHARED_MEMORY(),
+            new SOLUTION_DIR_PATH(),
+            new SOLUTION_LENGTH_RANGE(),
+            new MAX_NO_SOLUTIONS(),
+            new NO_EXECUTIONS(),
+            new NO_GRAPHS(),
+            new USE_WORKFLOW_INPUT(),
+            new USE_ALL_GENERATED_DATA(),
+            new DEBUG_MODE(),
+            new TOOL_SEQ_REPEAT(),
+            new PROGRAM_OUTPUTS(null),
+            new PROGRAM_INPUTS(null)
+    );
+
     /**
      * Object containing domain information needed for the execution.
      */
@@ -163,10 +163,24 @@ public class APERunConfig {
         setProgramOutputs(builder.programOutputs);
     }
 
+    /**
+     * Private constructor used by {@link APERunConfig#validate(JSONObject config, APEDomainSetup setup)}
+     * to create an empty instance.
+     */
     private APERunConfig(APEDomainSetup setup){
         this.apeDomainSetup = setup;
     }
 
+    /**
+     * Validate tje JSONObject for each RUN tag.
+     * If {@link ValidationResults#success()} ()} returns true,
+     * the configuration object can be safely used to create
+     * an APERunConfig object.
+     *
+     * @param json the configuration file
+     * @param setup the domain setup
+     * @return the validation results
+     */
     public static ValidationResults validate(JSONObject json, APEDomainSetup setup){
         APERunConfig dummy = new APERunConfig(setup);
         ValidationResults results = new ValidationResults();
@@ -248,10 +262,6 @@ public class APERunConfig {
         return new Builder();
     }
 
-    public static APEConfigTags getTags() {
-        return tag_info;
-    }
-
     public APEDomainSetup getApeDomainSetup() {
         return this.apeDomainSetup;
     }
@@ -322,9 +332,9 @@ public class APERunConfig {
     }
 
     /**
-     * Get the path to the directory where the graphs representation of the solutions should be stored.
+     * Get the path of the relative path in solution_dir_path.
      *
-     * @return
+     * @return absolute path of the relative path in solution_dir_path
      */
     public Path getSolutionDirPath2(String relativePath) {
         // relative paths should not start with '/' or '\'

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigDefaultValue.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigDefaultValue.java
@@ -4,6 +4,14 @@ import nl.uu.cs.ape.sat.configuration.APEConfigException;
 
 import javax.annotation.Nullable;
 
+/**
+ * In APE, a default value could be null. Simply checking
+ * value==null to see if a tag has a default value is not possible.
+ * This class contains a boolean specifying whether the the tag has
+ * a default value or not.
+ *
+ * @param <T> any type
+ */
 public class APEConfigDefaultValue<T> {
 
     private final boolean hasValue;
@@ -19,18 +27,44 @@ public class APEConfigDefaultValue<T> {
         value = null;
     }
 
+    /**
+     * Call this constructor if the tag does not have a default value.
+     *
+     * @param <T> any type
+     * @return default value container
+     */
     public static <T> APEConfigDefaultValue<T> noDefault() {
         return new APEConfigDefaultValue<>();
     }
 
+    /**
+     * Call this constructor if the tag has a default value.
+     * The value is allowed to be null.
+     *
+     * @param <T>   any type
+     * @param value the default value
+     * @return default value container
+     */
     public static <T> APEConfigDefaultValue<T> withDefault(@Nullable T value) {
         return new APEConfigDefaultValue<>(value);
     }
 
+    /**
+     * Returns a boolean indicating whether the container has a default value set or not.
+     *
+     * @return a boolean indicating whether the container has a default value set or not
+     */
     public boolean hasValue() {
         return this.hasValue;
     }
 
+    /**
+     * Get the default value that has been set by the tag.
+     * Make sure to call {@link APEConfigDefaultValue#hasValue()}
+     * to check whether a value has been set by the tag.
+     *
+     * @return the default value
+     */
     public T get() {
         if (!this.hasValue) {
             throw new APEConfigException("No default value present");

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigDependentTag.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigDependentTag.java
@@ -5,12 +5,44 @@ import org.json.JSONObject;
 
 import javax.inject.Provider;
 
+/**
+ * The Dependent Tags act the same way as an {@link APEConfigTag},
+ * but they take a Provider as an argument. This way, Tags can access
+ * data from other tags when they need it (dependency).
+ * <p>
+ * Instead of overriding the method constructFromJSON(JSONObject json);
+ * dependent tags need you to override constructFromJSON(JSONObject json, D1 dependency1, .., DN dependencyN);
+ * <p>
+ * Create instance of {@literal APEConfigDependentTag.One<T, D1>} for one dependency.</br>
+ * Create instance of {@literal APEConfigDependentTag.Two<T, D1, D2>} for two dependencies.</br>
+ * Create instance of {@literal APEConfigDependentTag.Three<T, D1, D2, D3>} for three dependencies.
+ * <p>
+ * Example, tag2(string type) is dependent on tag1(int type):</br>
+ * {@literal APEConfigTag<Integer> tag1 = ... ;}</br>
+ * {@literal APEConfigTag<String> tag2 = new APEConfigDependentTag.One<String, Integer>(() -> tag1.getValue()) { ... };}
+ * <p>
+ * Providers (callback functions) can be instantiated like this: () -> tag1.getValue()</br>
+ * or like this: tag1::getValue
+ * <p>
+ * Using providers instead of tag references makes sure tags can be dependent on other data as well (e.g. APEDomainSetup)
+ */
 public class APEConfigDependentTag {
 
+    /**
+     * APEConfigTag that has a dependency on type D1.
+     *
+     * @param <T>  any type that represents the tag
+     * @param <D1> any type that the tag has a dependency on
+     */
     public abstract static class One<T, D1> extends APEConfigTag<T> {
 
         private final Provider<D1> provider1;
 
+        /**
+         * Instantiates a new APEConfigTag with one dependency (D1).
+         *
+         * @param provider1 the provider of dependency1
+         */
         public One(Provider<D1> provider1) {
             this.provider1 = provider1;
         }
@@ -20,6 +52,13 @@ public class APEConfigDependentTag {
             return constructFromJSON(obj, provider1.get());
         }
 
+        /**
+         * Construct object T from JSON.
+         *
+         * @param obj        the configuration object
+         * @param dependency the dependency
+         * @return the constructed object from JSON
+         */
         protected abstract T constructFromJSON(JSONObject obj, D1 dependency);
 
         @Override
@@ -27,13 +66,34 @@ public class APEConfigDependentTag {
             return validate(value, provider1.get(), results);
         }
 
+        /**
+         * Validate object T using the dependencies.
+         *
+         * @param value       the tag value that must be validated
+         * @param dependency1 the first dependency
+         * @param results     the validation results
+         * @return the validation results
+         */
         protected abstract ValidationResults validate(T value, D1 dependency1, ValidationResults results);
     }
 
+    /**
+     * APEConfigTag that has dependencies on type D1 and D2.
+     *
+     * @param <T>  any type that represents the tag
+     * @param <D1> first type that the tag has a dependency on
+     * @param <D2> second type that the tag has a dependency on
+     */
     public abstract static class Two<T, D1, D2> extends One<T, D1> {
 
         private final Provider<D2> provider2;
 
+        /**
+         * Instantiates a new APEConfigTag with two dependencies (D1, D2).
+         *
+         * @param provider1 the provider of dependency1
+         * @param provider2 the provider of dependency2
+         */
         public Two(Provider<D1> provider1, Provider<D2> provider2) {
             super(provider1);
             this.provider2 = provider2;
@@ -44,20 +104,52 @@ public class APEConfigDependentTag {
             return constructFromJSON(obj, dependency1, provider2.get());
         }
 
-        protected abstract T constructFromJSON(JSONObject obj, D1 dependency, D2 dependency2);
+        /**
+         * Construct object T from JSON.
+         *
+         * @param obj         the configuration object
+         * @param dependency1 the first dependency
+         * @param dependency2 the second dependency
+         * @return the constructed object from JSON
+         */
+        protected abstract T constructFromJSON(JSONObject obj, D1 dependency1, D2 dependency2);
 
         @Override
         protected ValidationResults validate(T value, D1 dependency1, ValidationResults results) {
             return validate(value, dependency1, provider2.get(), results);
         }
 
+        /**
+         * Validate object T using the dependencies.
+         *
+         * @param value       the tag value that must be validated
+         * @param dependency1 the first dependency
+         * @param dependency2 the second dependency
+         * @param results     the validation results
+         * @return the validation results
+         */
         protected abstract ValidationResults validate(T value, D1 dependency1, D2 dependency2, ValidationResults results);
     }
 
+    /**
+     * APEConfigTag that has dependencies on type D1, D2 and D3.
+     *
+     * @param <T>  any type that represents the tag
+     * @param <D1> first type that the tag has a dependency on
+     * @param <D2> second type that the tag has a dependency on
+     * @param <D3> third type that the tag has a dependency on
+     */
     public abstract static class Three<T, D1, D2, D3> extends Two<T, D1, D2> {
 
         private final Provider<D3> provider3;
 
+        /**
+         * Instantiates a new APEConfigTag with three dependencies (D1, D2, D3).
+         *
+         * @param provider1 the provider of dependency1
+         * @param provider2 the provider of dependency2
+         * @param provider3 the provider of dependency3
+         */
         public Three(Provider<D1> provider1, Provider<D2> provider2, Provider<D3> provider3) {
             super(provider1, provider2);
             this.provider3 = provider3;
@@ -68,13 +160,32 @@ public class APEConfigDependentTag {
             return constructFromJSON(obj, dependency1, dependency2, provider3.get());
         }
 
-        protected abstract T constructFromJSON(JSONObject obj, D1 dependency, D2 dependency2, D3 dependency3);
+        /**
+         * Construct object T from JSON.
+         *
+         * @param obj         the configuration object
+         * @param dependency1 the first dependency
+         * @param dependency2 the second dependency
+         * @param dependency3 the third dependency
+         * @return the constructed object from JSON
+         */
+        protected abstract T constructFromJSON(JSONObject obj, D1 dependency1, D2 dependency2, D3 dependency3);
 
         @Override
         protected ValidationResults validate(T value, D1 dependency1, D2 dependency2, ValidationResults results) {
             return validate(value, dependency1, dependency2, provider3.get(), results);
         }
 
+        /**
+         * Validate object T using the dependencies.
+         *
+         * @param value       the tag value that must be validated
+         * @param dependency1 the first dependency
+         * @param dependency2 the second dependency
+         * @param dependency3 the third dependency
+         * @param results     the validation results
+         * @return the validation results
+         */
         protected abstract ValidationResults validate(T value, D1 dependency1, D2 dependency2, D3 dependency3, ValidationResults results);
     }
 }

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigDependentTag.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigDependentTag.java
@@ -12,16 +12,17 @@ import javax.inject.Provider;
  * <p>
  * Instead of overriding the method constructFromJSON(JSONObject json);
  * dependent tags need you to override constructFromJSON(JSONObject json, D1 dependency1, .., DN dependencyN);
+ *     <ul>
+ *         <li>Create instance of {@literal APEConfigDependentTag.One<T, D1>} for one dependency.</li>
+ *         <li>Create instance of {@literal APEConfigDependentTag.Two<T, D1, D2>} for two dependencies..</li>
+ *         <li>Create instance of {@literal APEConfigDependentTag.Three<T, D1, D2, D3>} for three dependencies.</li>
+ *     </ul>
  * <p>
- * Create instance of {@literal APEConfigDependentTag.One<T, D1>} for one dependency.</br>
- * Create instance of {@literal APEConfigDependentTag.Two<T, D1, D2>} for two dependencies.</br>
- * Create instance of {@literal APEConfigDependentTag.Three<T, D1, D2, D3>} for three dependencies.
- * <p>
- * Example, tag2(string type) is dependent on tag1(int type):</br>
- * {@literal APEConfigTag<Integer> tag1 = ... ;}</br>
+ * Example, tag2(string type) is dependent on tag1(int type):
+ * {@literal APEConfigTag<Integer> tag1 = ... ;}
  * {@literal APEConfigTag<String> tag2 = new APEConfigDependentTag.One<String, Integer>(() -> tag1.getValue()) { ... };}
  * <p>
- * Providers (callback functions) can be instantiated like this: () -> tag1.getValue()</br>
+ * Providers (callback functions) can be instantiated like this: {@literal () -> tag1.getValue()}
  * or like this: tag1::getValue
  * <p>
  * Using providers instead of tag references makes sure tags can be dependent on other data as well (e.g. APEDomainSetup)

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTag.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTag.java
@@ -123,7 +123,7 @@ public abstract class APEConfigTag<T> {
             return _default.get();
         }
 
-        throw APEConfigException.fieldNotSpecified(getTagName(), getType().toString());
+        throw APEConfigException.missingTag(getTagName());
     }
 
     /**

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTag.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTag.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
  * Call {@link APEConfigTag#getInfo()} to get an immutable version
  * of the tag.
  *
- * To implement a new Tag, the following methods should be implemented:</br>
+ * To implement a new Tag, the following methods should be implemented:
  * <ul>
  *   <li>String {@link APEConfigTag#getTagName()}</li>
  *   <li>String {@link APEConfigTag#getLabel()}</li>
@@ -151,7 +151,7 @@ public abstract class APEConfigTag<T> {
 
     /**
      * Sets the actual value of the Tag.
-     * It uses {@link APEConfigTag#validate(T value)}
+     * It uses {@link APEConfigTag#validate(Object)}
      * to check if the value is valid.
      *
      * @param value the value
@@ -246,7 +246,7 @@ public abstract class APEConfigTag<T> {
      * to add successes/failures to the results parameter that the user can use.
      * After that, return the results.
      *
-     * E.g.: results.add(getTagName(), "The maximum number of generated solutions should be greater or equal to 0.", value >= 0);
+     * E.g.: {@literal results.add(getTagName(), "The maximum number of generated solutions should be greater or equal to 0.", value >= 0);}
      *
      * @param value   the value
      * @param results the results

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTagFactory.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTagFactory.java
@@ -214,7 +214,7 @@ public class APEConfigTagFactory {
             }
 
             @Override
-            protected JSONObject getTypeConstraints() {
+            protected JSONObject getTagConstraints() {
                 return range.toJSON();
             }
         }
@@ -251,7 +251,7 @@ public class APEConfigTagFactory {
             }
 
             @Override
-            protected JSONObject getTypeConstraints() {
+            protected JSONObject getTagConstraints() {
                 return boundaries.toJSON();
             }
         }
@@ -310,7 +310,7 @@ public class APEConfigTagFactory {
             }
 
             @Override
-            protected JSONObject getTypeConstraints() {
+            protected JSONObject getTagConstraints() {
                 return new JSONObject().put("options", new JSONArray(getOptions()));
             }
         }

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTags.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTags.java
@@ -45,7 +45,7 @@ public class APEConfigTags {
     /**
      * Gets all tags that match the predicate in list format.
      *
-     * @param filter the filter (e.g. tag -> tag.isOptional())
+     * @param filter the filter (e.g. {@literal tag -> tag.isOptional()})
      * @return Gets all tags that match the predicate in list format
      */
     public List<APEConfigTag.Info<?>> getAll(Predicate<APEConfigTag<?>> filter) {

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTags.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTags.java
@@ -16,19 +16,19 @@ public class APEConfigTags {
         this.all_tags = all_tags;
     }
 
-    public List<APEConfigTag.Info> getObligatory() {
+    public List<APEConfigTag.Info<?>> getObligatory() {
         return getAll(APEConfigTag::isObligatory);
     }
 
-    public List<APEConfigTag.Info> getOptional() {
+    public List<APEConfigTag.Info<?>> getOptional() {
         return getAll(APEConfigTag::isOptional);
     }
 
-    public List<APEConfigTag.Info> getAll(Predicate<APEConfigTag<?>> filter) {
+    public List<APEConfigTag.Info<?>> getAll(Predicate<APEConfigTag<?>> filter) {
         return Arrays.stream(all_tags).filter(filter).map(APEConfigTag::getInfo).collect(Collectors.toList());
     }
 
-    public List<APEConfigTag.Info> getAll() {
+    public List<APEConfigTag.Info<?>> getAll() {
         return Arrays.stream(all_tags).map(APEConfigTag::getInfo).collect(Collectors.toList());
     }
 

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTags.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTags.java
@@ -8,30 +8,65 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * A container for APEConfigTag's, that makes it easier to filter tags
+ */
 public class APEConfigTags {
 
     private final APEConfigTag<?>[] all_tags;
 
+    /**
+     * Instantiates a new APEConfigTags based on a set of tags.
+     *
+     * @param all_tags the all tags
+     */
     public APEConfigTags(APEConfigTag<?>... all_tags) {
         this.all_tags = all_tags;
     }
 
+    /**
+     * Gets all tags that are obligatory.
+     *
+     * @return all tags that are obligatory
+     */
     public List<APEConfigTag.Info<?>> getObligatory() {
         return getAll(APEConfigTag::isObligatory);
     }
 
+    /**
+     * Gets all tags that are optional.
+     *
+     * @return all tags that are optional.
+     */
     public List<APEConfigTag.Info<?>> getOptional() {
         return getAll(APEConfigTag::isOptional);
     }
 
+    /**
+     * Gets all tags that match the predicate in list format.
+     *
+     * @param filter the filter (e.g. tag -> tag.isOptional())
+     * @return Gets all tags that match the predicate in list format
+     */
     public List<APEConfigTag.Info<?>> getAll(Predicate<APEConfigTag<?>> filter) {
         return Arrays.stream(all_tags).filter(filter).map(APEConfigTag::getInfo).collect(Collectors.toList());
     }
 
+    /**
+     * Gets all tags in list format.
+     *
+     * @return all tags in list format
+     */
     public List<APEConfigTag.Info<?>> getAll() {
         return Arrays.stream(all_tags).map(APEConfigTag::getInfo).collect(Collectors.toList());
     }
 
+    /**
+     * Create a JSONObject containing all the info on tags, e.g.: {"tags": [ .. tags ..]}
+     * This method uses {@link APEConfigTag.Info#toJSON()} to convert the tags to json.
+     *
+     * @return a JSONObject containing all the info on tags
+     */
     public JSONObject toJSON() {
         return new JSONObject()
                 .put("tags", new JSONArray(getAll().stream().map(APEConfigTag.Info::toJSON).collect(Collectors.toSet())));

--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/validation/ValidationResults.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/validation/ValidationResults.java
@@ -93,11 +93,22 @@ public class ValidationResults {
 
     /**
      * Indicates whether this class contains at least one fail.
+     * This method is the counterpart of {@link ValidationResults#success()}
      *
      * @return a boolean indicating whether this class contains at least one fail
      */
     public boolean hasFails() {
         return results.stream().anyMatch(ValidationResult::isFail);
+    }
+
+    /**
+     * Indicates whether this class passed all validation criteria.
+     * This method is the counterpart of {@link ValidationResults#hasFails()}
+     *
+     * @return a boolean indicating whether this class passed all validation criteria
+     */
+    public boolean success() {
+        return !hasFails();
     }
 
     /**

--- a/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTagTest.java
+++ b/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTagTest.java
@@ -51,7 +51,7 @@ public class APEConfigTagTest {
         assertFalse(results.hasFails());
 
         /* Test missing obligatory tag  */
-        List<String> tags = APECoreConfig.getTags().getObligatory().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        List<String> tags = APECoreConfig.getTags().getObligatory().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
@@ -66,7 +66,7 @@ public class APEConfigTagTest {
         }
 
         /* Test missing optional tag  */
-        tags = APECoreConfig.getTags().getOptional().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        tags = APECoreConfig.getTags().getOptional().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
@@ -78,7 +78,7 @@ public class APEConfigTagTest {
         }
 
         /* Test incorrect tag  */
-        tags = APECoreConfig.getTags().getAll().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        tags = APECoreConfig.getTags().getAll().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config)
@@ -109,7 +109,7 @@ public class APEConfigTagTest {
         assertFalse(results.hasFails());
 
         /* Test missing obligatory tag  */
-        List<String> tags = APERunConfig.getTags().getObligatory().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        List<String> tags = APERunConfig.getTags().getObligatory().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
@@ -124,7 +124,7 @@ public class APEConfigTagTest {
         }
 
         /* Test missing optional tag  */
-        tags = APERunConfig.getTags().getOptional().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        tags = APERunConfig.getTags().getOptional().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
@@ -136,7 +136,7 @@ public class APEConfigTagTest {
         }
 
         /* Test incorrect tag  */
-        tags = APERunConfig.getTags().getAll().stream().map(APEConfigTag.Info::getTagName).collect(Collectors.toList());
+        tags = APERunConfig.getTags().getAll().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config)

--- a/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTagTest.java
+++ b/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTagTest.java
@@ -25,7 +25,7 @@ public class APEConfigTagTest {
 
         System.out.println("Test type tags..");
 
-        for (APEConfigTag.Info<?> tag : APERunConfig.getTags().getAll()) {
+        for (APEConfigTag.Info<?> tag : APERunConfig.TAGS.getAll()) {
 
             if (tag.type == APEConfigTag.TagType.INTEGER) {
                 System.out.printf("Web API shows `%s` box for tag `%s`, with min:`%s` and max:`%s`\n", tag.type, tag.label, tag.constraints.getInt("min"), tag.constraints.getInt("max"));
@@ -33,8 +33,8 @@ public class APEConfigTagTest {
         }
 
         System.out.printf("\n### Display all tag info ####\nCORE:\n%s\n\nRUN:\n%s\n",
-                APECoreConfig.getTags().toJSON().toString(3),
-                APERunConfig.getTags().toJSON().toString(3));
+                APECoreConfig.TAGS.toJSON().toString(3),
+                APERunConfig.TAGS.toJSON().toString(3));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class APEConfigTagTest {
         assertFalse(results.hasFails());
 
         /* Test missing obligatory tag  */
-        List<String> tags = APECoreConfig.getTags().getObligatory().stream().map(info -> info.tag_name).collect(Collectors.toList());
+        List<String> tags = APECoreConfig.TAGS.getObligatory().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
@@ -66,7 +66,7 @@ public class APEConfigTagTest {
         }
 
         /* Test missing optional tag  */
-        tags = APECoreConfig.getTags().getOptional().stream().map(info -> info.tag_name).collect(Collectors.toList());
+        tags = APECoreConfig.TAGS.getOptional().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
@@ -78,7 +78,7 @@ public class APEConfigTagTest {
         }
 
         /* Test incorrect tag  */
-        tags = APECoreConfig.getTags().getAll().stream().map(info -> info.tag_name).collect(Collectors.toList());
+        tags = APECoreConfig.TAGS.getAll().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config)
@@ -109,7 +109,7 @@ public class APEConfigTagTest {
         assertFalse(results.hasFails());
 
         /* Test missing obligatory tag  */
-        List<String> tags = APERunConfig.getTags().getObligatory().stream().map(info -> info.tag_name).collect(Collectors.toList());
+        List<String> tags = APERunConfig.TAGS.getObligatory().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
@@ -124,7 +124,7 @@ public class APEConfigTagTest {
         }
 
         /* Test missing optional tag  */
-        tags = APERunConfig.getTags().getOptional().stream().map(info -> info.tag_name).collect(Collectors.toList());
+        tags = APERunConfig.TAGS.getOptional().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config);
@@ -136,7 +136,7 @@ public class APEConfigTagTest {
         }
 
         /* Test incorrect tag  */
-        tags = APERunConfig.getTags().getAll().stream().map(info -> info.tag_name).collect(Collectors.toList());
+        tags = APERunConfig.TAGS.getAll().stream().map(info -> info.tag_name).collect(Collectors.toList());
         for (String tag : tags) {
 
             JSONObject altered_config = APEUtils.clone(correct_config)

--- a/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTest.java
+++ b/src/test/java/nl/uu/cs/ape/sat/configuration/APEConfigTest.java
@@ -114,22 +114,22 @@ class APEConfigTest {
     public void testMissingTags() {
 
         /* Missing one of the obligatory core tags should result in an exception while creating the framework. */
-        for (APEConfigTag.Info info : APECoreConfig.getTags().getObligatory()) {
+        for (APEConfigTag.Info<?> info : APECoreConfig.TAGS.getObligatory()) {
             JSONObject obj = getCorrectTemplate();
             obj.remove(info.tag_name);
-            assertThrows(JSONException.class, () -> new APECoreConfig(obj));
+            assertThrows(APEConfigException.class, () -> new APECoreConfig(obj));
         }
 
         /* Missing one of the obligatory run tags should  result in an exception while executing the run phase. */
-        for (APEConfigTag.Info tag : APERunConfig.getTags().getObligatory()) {
+        for (APEConfigTag.Info<?> tag : APERunConfig.TAGS.getObligatory()) {
             JSONObject obj = getCorrectTemplate();
             obj.remove(tag.tag_name);
             assertDoesNotThrow(() -> new APECoreConfig(obj));
-            assertThrows(JSONException.class, () -> setupRun(obj));
+            assertThrows(APEConfigException.class, () -> setupRun(obj));
         }
 
         /* Missing one of the optional tags should not throw an exception, but should display a warning. */
-        for (APEConfigTag.Info tag_info : APECoreConfig.getTags().getOptional()) {
+        for (APEConfigTag.Info<?> tag_info : APECoreConfig.TAGS.getOptional()) {
             JSONObject obj = getCorrectTemplate();
             obj.remove(tag_info.tag_name);
             assertDoesNotThrow(() -> new APECoreConfig(obj));


### PR DESCRIPTION
Added:
- Created/edited Javadoc for:
  - APEConfigDefaultValue.java
  - APEConfigTag.java
  - APEConfigDependentTag.java
  - APEFiles.java
  - APE.java
  - APECConfigException.java
  - APECoreConfig.java
  - APERunConfig.java
- Fixed raw use of parameterized class `Info<T>`
- Rename getTypeConstraints to getTagConstraints
- Change static getTags() to immutable static TAGS
- Reposition code in core/run config
- Clean code
- Solve additional javadoc errors
  - `mvn javadoc:javadoc` build succeeds right now