### PR TITLE
[REFACTOR] - Removed () signs from timeout field.

### DIFF
--- a/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTagFactory.java
+++ b/src/main/java/nl/uu/cs/ape/sat/configuration/tags/APEConfigTagFactory.java
@@ -754,7 +754,7 @@ public class APEConfigTagFactory {
 
             @Override
             public String getTagName() {
-                return "timeout(sec)";
+                return "timeout_sec";
             }
 
             @Override


### PR DESCRIPTION
 Having these characters makes it impossible for the run configuration json to be parsed to a javascript object. It's better to limit the characters of keys to only letters and underscores. This way, a json file can be easily ported to a javascript object. It's also more consistent with the rest of the file.
