### PR TITLE
[FIX] Synthesis flag typo

### DIFF
--- a/src/main/java/nl/uu/cs/ape/sat/APE.java
+++ b/src/main/java/nl/uu/cs/ape/sat/APE.java
@@ -321,7 +321,7 @@ public class APE {
 		if ((allSolutions.getNumberOfSolutions() >= allSolutions.getMaxNumberOfSolutions() - 1)) {
 			allSolutions.setFlag(SynthesisFlag.NONE);
 		} else if (solutionLength == runConfig.getSolutionLength().getMax()) {
-			allSolutions.setFlag(SynthesisFlag.MAX_LENGHT);
+			allSolutions.setFlag(SynthesisFlag.MAX_LENGTH);
 		} else if(APEUtils.timerTimeLeft("globalTimer", runConfig.getTimeoutMs()) <= 0) {
 			allSolutions.setFlag(SynthesisFlag.TIMEOUT);
 		} else {

--- a/src/main/java/nl/uu/cs/ape/sat/APE.java
+++ b/src/main/java/nl/uu/cs/ape/sat/APE.java
@@ -450,7 +450,7 @@ public class APE {
 		if (graphsFolder == null || noGraphs == null || noGraphs == 0 || allSolutions.isEmpty()) {
 			return false;
 		}
-		APEUtils.printHeader(null, "Geneating graphical representation", "of the first " + noGraphs + " workflows");
+		APEUtils.printHeader(null, "Generating graphical representation", "of the first " + noGraphs + " workflows");
 		APEUtils.timerStart("drawingGraphs", true);
 		System.out.println();
 		/* Removing the existing files from the file system. */

--- a/src/main/java/nl/uu/cs/ape/sat/models/enums/SynthesisFlag.java
+++ b/src/main/java/nl/uu/cs/ape/sat/models/enums/SynthesisFlag.java
@@ -17,7 +17,7 @@ public enum SynthesisFlag {
     /**
      * Synthesis search was interrupted because it reached the maximum workflow length.
      */
-    MAX_LENGHT,
+    MAX_LENGTH,
     
     /**
      * Synthesis was interrupted because it reached the TIMEOUT.
@@ -37,7 +37,7 @@ public enum SynthesisFlag {
     public String getMessage() {
         if (this == SynthesisFlag.NONE) {
             return "";
-        } else if(this == SynthesisFlag.MAX_LENGHT) {
+        } else if(this == SynthesisFlag.MAX_LENGTH) {
             return "Synthesis was interrupted because it reached the maximum workflow length.";
         } else if(this == SynthesisFlag.TIMEOUT){
         	return "Synthesis was interrupted because it reached the TIMEOUT.";


### PR DESCRIPTION
While working on APE Web, I found a typo in the SynthesisFlag enum. This fixes the typo.