### PR TITLE
[FIX] Synthesis flag clarification

### DIFF
--- a/src/main/java/nl/uu/cs/ape/sat/APE.java
+++ b/src/main/java/nl/uu/cs/ape/sat/APE.java
@@ -335,14 +335,14 @@ public class APE {
 			/* Increase the size of the workflow for the next depth iteration */
 			solutionLength++;
 		}
-		
+
 		if ((allSolutions.getNumberOfSolutions() >= allSolutions.getMaxNumberOfSolutions() - 1)) {
 			allSolutions.setFlag(SynthesisFlag.NONE);
 		} else if(APEUtils.timerTimeLeft("globalTimer", runConfig.getTimeoutMs()) <= 0) {
 			allSolutions.setFlag(SynthesisFlag.TIMEOUT);
 		} else if (allSolutions.getNumberOfSolutions() == 0) {
 			allSolutions.setFlag(SynthesisFlag.UNSAT);
-		} else if (solutionLength == runConfig.getSolutionLength().getMax()) {
+		} else if (solutionLength >= runConfig.getSolutionLength().getMax()) {
 			allSolutions.setFlag(SynthesisFlag.MAX_LENGTH);
 		} else {
 			allSolutions.setFlag(SynthesisFlag.UNKNOWN);

--- a/src/main/java/nl/uu/cs/ape/sat/models/enums/SynthesisFlag.java
+++ b/src/main/java/nl/uu/cs/ape/sat/models/enums/SynthesisFlag.java
@@ -21,12 +21,12 @@ public enum SynthesisFlag {
     UNSAT,
     
     /**
-     * Synthesis search was interrupted because it reached the maximum workflow length.
+     * Synthesis search was interrupted because it reached the maximum workflow length without finding the specified number of solutions.
      */
     MAX_LENGTH,
     
     /**
-     * Synthesis was interrupted because it reached the TIMEOUT.
+     * Synthesis was interrupted because it reached the maximum run duration.
      */
     TIMEOUT,
     
@@ -45,13 +45,13 @@ public enum SynthesisFlag {
         if (this == SynthesisFlag.NONE) {
             return "";
         } else if(this == SynthesisFlag.UNSAT){
-        	return "No solutions can be found for the given specification.";
+            return "No solutions can be found for the given specification.";
         } else if(this == SynthesisFlag.MAX_LENGTH) {
-            return "Synthesis was interrupted because it reached the maximum workflow length.";
+            return "Synthesis was interrupted because it reached the maximum workflow length without finding the specified number of solutions.";
         } else if(this == SynthesisFlag.TIMEOUT){
-        	return "Synthesis was interrupted because it reached the TIMEOUT.";
+            return "Synthesis was interrupted because it reached the maximum run duration.";
         } else {
-        	return "Synthesis was interrupted for an unknown reason.";
+            return "Synthesis was interrupted for an unknown reason.";
         }
     }
 


### PR DESCRIPTION
Summary:
- Fixes an issue where APE return `UNKNOWN` SynthesisFlag instead of `MAX_LENGTH` when an insufficient number of solutions is found when the maximum workflow length is reached.
- Improves the descriptions of some of the synthesis flags.