### PR TITLE
Move issue templates to the correct location

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Create a report to help improve the APE library
+title: '[BUG] '
+labels: 'bug'
+assignees: vedran-kasalica
+
+---
+
+**Note:** Not all fields are obligatory, but the more details you provide, the easier it will be for us to address the issue. Feel free to omit sections that you feel are not relevant to your report.
+
+## Description
+<!-- Provide a clear and concise description of what the bug is. -->
+
+## API/CLI Version
+<!-- Indicate whether this issue is related to the API or the CLI. -->
+- [ ] API
+- [ ] CLI
+
+## APE Version
+<!-- Specify the version of APE you're using. -->
+
+## Java Version
+<!-- Specify the Java version you're using. -->
+
+## Steps to Reproduce
+<!-- Provide detailed steps to reproduce the bug: -->
+1. 
+2. 
+3. 
+4. 
+
+## Expected Behavior
+<!-- Describe what you expected to happen. -->
+
+## Actual Behavior
+<!-- Describe what actually happened. Include complete error messages, screenshots, or logs if possible. -->
+
+## Possible Solution
+<!-- Suggest a fix/reason for the bug, if you have one in mind. -->
+
+## Additional Context
+<!-- Add any other context about the problem here, such as special configurations, environment details, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for the APE library
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: vedran-kasalica
+
+---
+
+**Note:** Not all fields are obligatory, but the more details you provide, the easier it will be for us to address the issue. Feel free to omit sections that you feel are not relevant to your report.
+
+## Feature Description
+<!-- Provide a clear and concise description of the feature or enhancement you're proposing. -->
+
+## Is this feature related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Describe the solution you'd like
+<!-- A detailed description of what you want to happen. -->
+
+## Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## API/CLI Impact
+<!-- Indicate whether this feature is related to the API, CLI, or both. -->
+- [ ] API
+- [ ] CLI
+- [ ] Both
+
+## Potential Benefits
+<!-- Describe the potential benefits this feature would bring to APE library users, such as increased efficiency, new capabilities, or compatibility improvements. -->
+
+## Additional Context
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
## Pull Request Overview
Move issue templates to the correct location so they can be identified by GitHub.
