### PR TITLE
[FIX] Update location of bio.tools domain config file

### DIFF
--- a/src/test/java/nl/uu/cs/ape/test/sat/ape/APEDomainSetupTest.java
+++ b/src/test/java/nl/uu/cs/ape/test/sat/ape/APEDomainSetupTest.java
@@ -28,7 +28,7 @@ class APEDomainSetupTest {
 
             assertFalse(toolJson.isEmpty());
             APE apeFramework = new APE(
-                    "https://raw.githubusercontent.com/Workflomics/tools-and-domains/refs/heads/main/domains/bio.tools/config.json");
+                    "https://raw.githubusercontent.com/Workflomics/tools-and-domains/refs/heads/main/domains/non-executable-domains/bio.tools/config.json");
 
             Module currModule = apeFramework.getDomainSetup()
                     .updateModuleFromJson(toolJson).get();


### PR DESCRIPTION
## Pull Request Overview
<!-- Briefly describe what this PR does (e.g., bug fix, feature addition, etc.). -->

This Pull Request fixes the URL of the bio.tools config JSON file that is used for APEDomainSetupTests, making the build in PS #125 fail

## Related Issue
<!-- Link the related issue using the format `#issue_number`. -->
#126 

## Changes Introduced
<!-- List the key changes made in this PR. -->

## How Has This Been Tested?
<!-- Briefly describe how you tested your changes. -->

## Checklist

- [x] I have referenced a related issue.
- [x] I have followed the project’s style guidelines.
- [x] My changes include tests, if applicable.
- [ ] All tests pass locally.
