### PR TITLE
[FIX] Omit trailing `0` for empty constraint in connected modules whi…

### DIFF
--- a/src/main/java/nl/uu/cs/ape/models/templateFormulas/SLTLxTemplateFormula.java
+++ b/src/main/java/nl/uu/cs/ape/models/templateFormulas/SLTLxTemplateFormula.java
@@ -429,6 +429,7 @@ public abstract class SLTLxTemplateFormula {
         for (Integer currComb : allCombinations) {
             constraints.append(currComb + " ");
         }
+
         constraints.append("0\n");
 
         // each state enforces usage of the corresponding tools and input
@@ -484,6 +485,7 @@ public abstract class SLTLxTemplateFormula {
         for (Integer currComb : allCombinations) {
             constraints.append(currComb + " ");
         }
+
         constraints.append("0\n");
 
         // each state enforces usage of the corresponding tools and input
@@ -545,7 +547,10 @@ public abstract class SLTLxTemplateFormula {
         for (Integer currComb : allCombinations) {
             constraints.append(currComb + " ");
         }
-        constraints.append("0\n");
+
+        if (!constraints.isEmpty()) {
+            constraints.append("0\n");
+        }
 
         // each combination enforces usage of the corresponding tools and output/inputs
         for (Integer currComb : allCombinations) {


### PR DESCRIPTION
…ch fixes an empty clause error when having only one tool in the workflow

## Pull Request Overview
<!-- Briefly describe what this PR does (e.g., bug fix, feature addition, etc.). -->
Fixes #119 which is introduced since APE generates an empty clause which is not accepted by minisat and thus not counted as clause. Hence, the computed count of clauses by APE does not match the ones recognised by minisat.

## Related Issue
<!-- Link the related issue using the format `#issue_number`. -->

#119 

## Changes Introduced
<!-- List the key changes made in this PR. -->

Since (in the case of a workflow of length 1) the output of op 1 cannot be reused, `connectedModules` seemingly yields an empty list of CNF literals. Thus, we check whether the constraints are empty and only set a clause delimiter (0) if there are constraints.

## How Has This Been Tested?
<!-- Briefly describe how you tested your changes. -->

Successfully tested locally with [config_bug119.json](https://github.com/user-attachments/files/22536498/config_bug119.json)

## Checklist

- [ ] I have referenced a related issue.
- [ ] I have followed the project’s style guidelines.
- [ ] My changes include tests, if applicable.
- [ ] All tests pass locally.
