### PR TITLE
[BUGFIX] The format string specifier for numbers was set to octal ...

### DIFF
--- a/src/main/java/nl/uu/cs/ape/APE.java
+++ b/src/main/java/nl/uu/cs/ape/APE.java
@@ -623,7 +623,7 @@ public class APE implements APEInterface {
 			return false;
 		}
 		final String timerID = "writingCWL";
-		APEUtils.printHeader(null, String.format("Writing the first %o solution(s) to CWL files", noCWLFiles));
+		APEUtils.printHeader(null, String.format("Writing the first %d solution(s) to CWL files", noCWLFiles));
 		APEUtils.timerStart(timerID, true);
 
 		final File cwlDir = cwlFolder.toFile();

--- a/src/main/java/nl/uu/cs/ape/solver/solutionStructure/ModuleNode.java
+++ b/src/main/java/nl/uu/cs/ape/solver/solutionStructure/ModuleNode.java
@@ -124,7 +124,7 @@ public class ModuleNode extends SolutionWorkflowNode {
         } else {
             this.outputCWLKeys = new ArrayList<>();
             for (int i = 1; i <= module.getModuleOutput().size(); i++) {
-                this.outputCWLKeys.add(String.format("%s_%s_%o",
+                this.outputCWLKeys.add(String.format("%s_%s_%d",
                         this.getNodeLabel(),
                         "out",
                         i));

--- a/src/main/java/nl/uu/cs/ape/solver/solutionStructure/SolutionWorkflow.java
+++ b/src/main/java/nl/uu/cs/ape/solver/solutionStructure/SolutionWorkflow.java
@@ -308,7 +308,7 @@ public class SolutionWorkflow {
      * @return The file name of the solution file (without the file extension).
      */
     public String getFileName() {
-        return String.format("%s%o", getFileNamePrefix(), getIndex() + 1);
+        return String.format("%s%d", getFileNamePrefix(), getIndex() + 1);
     }
 
     public String getDescriptiveName() {

--- a/src/main/java/nl/uu/cs/ape/solver/solutionStructure/cwl/AbstractCWLCreator.java
+++ b/src/main/java/nl/uu/cs/ape/solver/solutionStructure/cwl/AbstractCWLCreator.java
@@ -49,7 +49,7 @@ public class AbstractCWLCreator extends CWLWorkflowBase {
         cwlRepresentation.append("inputs:").append("\n");
         // Inputs
         for (TypeNode typeNode : solution.getWorkflowInputTypeStates()) {
-            String inputName = String.format("input_%o", workflowParameters.size() + 1);
+            String inputName = String.format("input_%d", workflowParameters.size() + 1);
             addParameter(typeNode, inputName);
             cwlRepresentation
                     // Name
@@ -79,7 +79,7 @@ public class AbstractCWLCreator extends CWLWorkflowBase {
             cwlRepresentation
                     // Name
                     .append(ind(1))
-                    .append(String.format("output_%o", i))
+                    .append(String.format("output_%d", i))
                     .append(":\n")
                     // Data type
                     .append(ind(2))

--- a/src/main/java/nl/uu/cs/ape/solver/solutionStructure/cwl/CWLToolBase.java
+++ b/src/main/java/nl/uu/cs/ape/solver/solutionStructure/cwl/CWLToolBase.java
@@ -182,7 +182,7 @@ public abstract class CWLToolBase {
      * @return The name of the input or output.
      */
     protected String generateInputOrOutputName(ModuleNode moduleNode, String indicator, int n) {
-        return String.format("%s_%s_%o",
+        return String.format("%s_%s_%d",
                 moduleNode.getNodeLabel(),
                 indicator,
                 n);
@@ -197,9 +197,9 @@ public abstract class CWLToolBase {
     protected String stepName(ModuleNode moduleNode) {
         int stepNumber = moduleNode.getAutomatonState().getLocalStateNumber();
         if (stepNumber < 10) {
-            return String.format("%s_0%o", moduleNode.getUsedModule().getPredicateLabel(), stepNumber);
+            return String.format("%s_0%d", moduleNode.getUsedModule().getPredicateLabel(), stepNumber);
         } else {
-            return String.format("%s_%o", moduleNode.getUsedModule().getPredicateLabel(), stepNumber);
+            return String.format("%s_%d", moduleNode.getUsedModule().getPredicateLabel(), stepNumber);
         }
     }
 

--- a/src/main/java/nl/uu/cs/ape/solver/solutionStructure/cwl/CWLWorkflowBase.java
+++ b/src/main/java/nl/uu/cs/ape/solver/solutionStructure/cwl/CWLWorkflowBase.java
@@ -86,7 +86,7 @@ public abstract class CWLWorkflowBase {
      * @return The name of the workflow.
      */
     private String getWorkflowName() {
-        return String.format("WorkflowNo_%o", solution.getIndex());
+        return String.format("WorkflowNo_%d", solution.getIndex());
     }
 
     /**
@@ -115,7 +115,7 @@ public abstract class CWLWorkflowBase {
      * @return The name of the input or output.
      */
     protected String generateInputOrOutputName(ModuleNode moduleNode, String indicator, int n) {
-        return String.format("%s_%s_%o",
+        return String.format("%s_%s_%d",
                 moduleNode.getNodeLabel(),
                 indicator,
                 n);
@@ -130,9 +130,9 @@ public abstract class CWLWorkflowBase {
     protected String stepName(ModuleNode moduleNode) {
         int stepNumber = moduleNode.getAutomatonState().getLocalStateNumber();
         if (stepNumber < 10) {
-            return String.format("%s_0%o", moduleNode.getUsedModule().getPredicateLabel(), stepNumber);
+            return String.format("%s_0%d", moduleNode.getUsedModule().getPredicateLabel(), stepNumber);
         } else {
-            return String.format("%s_%o", moduleNode.getUsedModule().getPredicateLabel(), stepNumber);
+            return String.format("%s_%d", moduleNode.getUsedModule().getPredicateLabel(), stepNumber);
         }
     }
 

--- a/src/main/java/nl/uu/cs/ape/solver/solutionStructure/cwl/DefaultCWLCreator.java
+++ b/src/main/java/nl/uu/cs/ape/solver/solutionStructure/cwl/DefaultCWLCreator.java
@@ -79,7 +79,7 @@ public class DefaultCWLCreator extends CWLWorkflowBase {
                     currTypeFormat = type.getPredicateID();
                 }
             }
-            String inputName = String.format("input_%o", i++);
+            String inputName = String.format("input_%d", i++);
             addNewParameterToMap(typeNode, inputName);
             inputsInCWL
                     // Name
@@ -129,7 +129,7 @@ public class DefaultCWLCreator extends CWLWorkflowBase {
             cwlRepresentation
                     // Name
                     .append(ind(1))
-                    .append(String.format("output_%o", i))
+                    .append(String.format("output_%d", i))
                     .append(":\n")
                     // Data type
                     .append(ind(2))


### PR DESCRIPTION
... leading to wrong numbering

## Pull Request Overview
<!-- Briefly describe what this PR does (e.g., bug fix, feature addition, etc.). -->

Correction of format string specifiers for integers.

## Related Issue
<!-- Link the related issue using the format `#issue_number`. -->

#112 

## Changes Introduced
<!-- List the key changes made in this PR. -->

In some spots, integers were injected into a format string but as specifier, `%o` was used, making the number octal

## How Has This Been Tested?
<!-- Briefly describe how you tested your changes. -->

## Checklist

- [x] I have referenced a related issue.
- [x] I have followed the project’s style guidelines.
- [ ] My changes include tests, if applicable.
- [x] All tests pass locally.
