### PR TITLE
Prepare v2.5.3 release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,3 +16,4 @@
 - [ ] I have followed the project’s style guidelines.
 - [ ] My changes include tests, if applicable.
 - [ ] All tests pass locally.
+- [ ] I have added myself to the CITATION.cff file, if not already present.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,6 +15,11 @@ authors:
     email: anna-lena.lamprecht@uni-potsdam.de
     affiliation: University of Potsdam, Germany
     orcid: 'https://orcid.org/0000-0003-1953-5606'
+  - given-names: Mario
+    family-names: Frank
+    email: mario.frank@uni-potsdam.de
+    affiliation: University of Potsdam, Germany
+    orcid: 'https://orcid.org/0000-0001-8888-7475'
   - family-names: Koen
     given-names: Haverkort
     affiliation: Utrect University, Netherlands
@@ -36,6 +41,3 @@ keywords:
   - automated workflow composition
   - workflow synthesis
 license: Apache-2.0
-commit: 8d13cb975dacf7e757cd5faf2276449bea16f93c
-version: 2.2.0
-date-released: '2023-11-14'

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.14.0</version>
+			<version>3.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.sanctuuary</groupId>
 	<artifactId>APE</artifactId>
-	<version>2.5.2</version>
+	<version>2.5.3</version>
 	<packaging>jar</packaging>
 	<name>io.github.sanctuuary:APE</name>
 	<description>APE is a command line tool and an API for the automated exploration of possible computational pipelines (workflows) from large collections of computational tools.</description>


### PR DESCRIPTION
## Pull Request Overview
Prepare the repo for the v2.5.3 release.


## Changes Introduced
- Update APE version to 2.5.3
- Added the new contributors to the `cff` file. The file is used on release to automatically generate the citation data published to Zenodo.
- Updated the PR template to require new contributors to add their name to the contributors list in the `cff` file.
- Bump `commons-lang3` to 2.19 (a bit newer version than requested in https://github.com/sanctuuary/APE/pull/125)


## Checklist

- [ ] I have referenced a related issue.
- [x] I have followed the project’s style guidelines.
- [ ] My changes include tests, if applicable.
- [ ] All tests pass locally.
