### PR TITLE
Refactor the CWLParser constructors

### DIFF
--- a/src/main/java/nl/uu/cs/ape/utils/cwl_parser/CWLParser.java
+++ b/src/main/java/nl/uu/cs/ape/utils/cwl_parser/CWLParser.java
@@ -26,14 +26,24 @@ public class CWLParser {
 
     /**
      * Constructor to load CWL from a URL string
+     * @param inputStream The input stream containing the CWL file content.
+     * @param uriString URI string pointing to the CWL file.
+     * @throws IOException if the file cannot be read
+     */
+    protected CWLParser(InputStream inputStream, String uriString) throws IOException {
+        String fileContent = new String(inputStream.readAllBytes());
+        inputStream.close();
+        cwlToolContent = (CommandLineTool) RootLoader.loadDocument(fileContent, uriString);
+
+    }
+
+    /**
+     * Constructor to load CWL from a URL string
      * @param urlString URL string pointing to the CWL file
      * @throws IOException if the file cannot be read
      */
     public CWLParser(String urlString) throws IOException {
-        InputStream inputStream = new FileInputStream(APEFiles.readPathToFile(urlString));
-        String fileContent = new String(inputStream.readAllBytes());
-        inputStream.close();
-        cwlToolContent = (CommandLineTool) RootLoader.loadDocument(fileContent, urlString);
+        this(new FileInputStream(APEFiles.readPathToFile(urlString)), urlString);
     }
 
     /**
@@ -43,10 +53,7 @@ public class CWLParser {
      * @throws IOException if the file cannot be read
      */
     public CWLParser(Path filePath) throws IOException {
-        InputStream inputStream = Files.newInputStream(filePath);
-        String fileContent = new String(inputStream.readAllBytes());
-        inputStream.close();
-        cwlToolContent = (CommandLineTool) RootLoader.loadDocument(fileContent, filePath.toString());
+        this(Files.newInputStream(filePath), filePath.toString());
     }
 
     /**


### PR DESCRIPTION
## Pull Request Overview
<!-- Briefly describe what this PR does (e.g., bug fix, feature addition, etc.). -->

This PR refactors the two public constructors that share mostly identical functionality.
A new, protected constructor is introduced that is reused by the public ones.

## Related Issue
<!-- Link the related issue using the format `#issue_number`. -->

Resolves #139 

## Changes Introduced
<!-- List the key changes made in this PR. -->

See above.

## How Has This Been Tested?
<!-- Briefly describe how you tested your changes. -->

Running test suite locally which also includes the `TestCWLParser` which explicitly tackles the relevant constructors.

## Checklist

- [x] I have referenced a related issue.
- [x] I have followed the project’s style guidelines.
- [x] My changes include tests, if applicable.
- [x] All tests pass locally.
- [x] I have added myself to the CITATION.cff file, if not already present.
